### PR TITLE
Fix frontend tests and apply Biome lint rules

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import App from './App';
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import App from "./App";
 
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+test("renders learn react link", () => {
+	render(<App />);
+	const linkElement = screen.getByText(/learn react/i);
+	expect(linkElement).toBeInTheDocument();
 });

--- a/frontend/src/components/BattleMap.test.tsx
+++ b/frontend/src/components/BattleMap.test.tsx
@@ -1,111 +1,110 @@
-import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import BattleMap from './BattleMap';
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import BattleMap from "./BattleMap";
 
-describe('BattleMap', () => {
-  it('renders battle map with image when mapUrl is provided', () => {
-    const mapUrl = 'https://example.com/battle-map.jpg';
-    render(<BattleMap mapUrl={mapUrl} />);
+describe("BattleMap", () => {
+	it("renders battle map with image when mapUrl is provided", () => {
+		const mapUrl = "https://example.com/battle-map.jpg";
+		render(<BattleMap mapUrl={mapUrl} />);
 
-    expect(screen.getByText('Battle Map')).toBeInTheDocument();
-    
-    const image = screen.getByRole('img');
-    expect(image).toBeInTheDocument();
-    expect(image).toHaveAttribute('src', mapUrl);
-    expect(image).toHaveAttribute('alt', 'Tactical Battle Map');
-  });
+		expect(screen.getByText("Battle Map")).toBeInTheDocument();
 
-  it('renders empty state when mapUrl is null', () => {
-    render(<BattleMap mapUrl={null} />);
+		const image = screen.getByRole("img");
+		expect(image).toBeInTheDocument();
+		expect(image).toHaveAttribute("src", mapUrl);
+		expect(image).toHaveAttribute("alt", "Tactical Battle Map");
+	});
 
-    expect(screen.getByText('Battle Map')).toBeInTheDocument();
-    expect(screen.getByText('No battle map available')).toBeInTheDocument();
-    expect(screen.queryByRole('img')).not.toBeInTheDocument();
-  });
+	it("renders empty state when mapUrl is null", () => {
+		render(<BattleMap mapUrl={null} />);
 
-  it('renders empty state when mapUrl is empty string', () => {
-    render(<BattleMap mapUrl="" />);
+		expect(screen.getByText("Battle Map")).toBeInTheDocument();
+		expect(screen.getByText("No battle map available")).toBeInTheDocument();
+		expect(screen.queryByRole("img")).not.toBeInTheDocument();
+	});
 
-    expect(screen.getByText('No battle map available')).toBeInTheDocument();
-    expect(screen.queryByRole('img')).not.toBeInTheDocument();
-  });
+	it("renders empty state when mapUrl is empty string", () => {
+		render(<BattleMap mapUrl="" />);
 
-  it('shows expand button initially', () => {
-    render(<BattleMap mapUrl="test.jpg" />);
+		expect(screen.getByText("No battle map available")).toBeInTheDocument();
+		expect(screen.queryByRole("img")).not.toBeInTheDocument();
+	});
 
-    const button = screen.getByRole('button', { name: 'Expand' });
-    expect(button).toBeInTheDocument();
-  });
+	it("shows expand button initially", () => {
+		render(<BattleMap mapUrl="test.jpg" />);
 
-  it('toggles expand/minimize when button is clicked', async () => {
-    
-    render(<BattleMap mapUrl="test.jpg" />);
+		const button = screen.getByRole("button", { name: "Expand" });
+		expect(button).toBeInTheDocument();
+	});
 
-    const button = screen.getByRole('button', { name: 'Expand' });
-    
-    // Initially should show Expand
-    expect(button).toHaveTextContent('Expand');
+	it("toggles expand/minimize when button is clicked", async () => {
+		render(<BattleMap mapUrl="test.jpg" />);
 
-    // Click to expand
-    await userEvent.click(button);
-    expect(screen.getByRole('button', { name: 'Minimize' })).toBeInTheDocument();
+		const button = screen.getByRole("button", { name: "Expand" });
 
-    // Click to minimize
-    await userEvent.click(screen.getByRole('button', { name: 'Minimize' }));
-    expect(screen.getByRole('button', { name: 'Expand' })).toBeInTheDocument();
-  });
+		// Initially should show Expand
+		expect(button).toHaveTextContent("Expand");
 
-  it('applies expanded CSS class when expanded', async () => {
-    
-    const { container } = render(<BattleMap mapUrl="test.jpg" />);
+		// Click to expand
+		await userEvent.click(button);
+		expect(
+			screen.getByRole("button", { name: "Minimize" }),
+		).toBeInTheDocument();
 
-    const battleMap = container.querySelector('.battle-map');
-    expect(battleMap).not.toHaveClass('expanded');
+		// Click to minimize
+		await userEvent.click(screen.getByRole("button", { name: "Minimize" }));
+		expect(screen.getByRole("button", { name: "Expand" })).toBeInTheDocument();
+	});
 
-    const expandButton = screen.getByRole('button', { name: 'Expand' });
-    await userEvent.click(expandButton);
+	it("applies expanded CSS class when expanded", async () => {
+		const { container } = render(<BattleMap mapUrl="test.jpg" />);
 
-    expect(battleMap).toHaveClass('expanded');
-  });
+		const battleMap = container.querySelector(".battle-map");
+		expect(battleMap).not.toHaveClass("expanded");
 
-  it('removes expanded CSS class when minimized', async () => {
-    
-    const { container } = render(<BattleMap mapUrl="test.jpg" />);
+		const expandButton = screen.getByRole("button", { name: "Expand" });
+		await userEvent.click(expandButton);
 
-    const battleMap = container.querySelector('.battle-map');
-    const toggleButton = screen.getByRole('button');
+		expect(battleMap).toHaveClass("expanded");
+	});
 
-    // Expand first
-    await userEvent.click(toggleButton);
-    expect(battleMap).toHaveClass('expanded');
+	it("removes expanded CSS class when minimized", async () => {
+		const { container } = render(<BattleMap mapUrl="test.jpg" />);
 
-    // Then minimize
-    await userEvent.click(toggleButton);
-    expect(battleMap).not.toHaveClass('expanded');
-  });
+		const battleMap = container.querySelector(".battle-map");
+		const toggleButton = screen.getByRole("button");
 
-  it('has correct CSS classes', () => {
-    const { container } = render(<BattleMap mapUrl="test.jpg" />);
+		// Expand first
+		await userEvent.click(toggleButton);
+		expect(battleMap).toHaveClass("expanded");
 
-    expect(container.querySelector('.battle-map')).toBeInTheDocument();
-    expect(container.querySelector('.battle-map-header')).toBeInTheDocument();
-    expect(container.querySelector('.map-container')).toBeInTheDocument();
-    expect(container.querySelector('.toggle-button')).toBeInTheDocument();
-  });
+		// Then minimize
+		await userEvent.click(toggleButton);
+		expect(battleMap).not.toHaveClass("expanded");
+	});
 
-  it('has correct CSS classes for empty state', () => {
-    const { container } = render(<BattleMap mapUrl={null} />);
+	it("has correct CSS classes", () => {
+		const { container } = render(<BattleMap mapUrl="test.jpg" />);
 
-    expect(container.querySelector('.battle-map')).toBeInTheDocument();
-    expect(container.querySelector('.map-container')).toBeInTheDocument();
-    expect(container.querySelector('.empty-map-state')).toBeInTheDocument();
-  });
+		expect(container.querySelector(".battle-map")).toBeInTheDocument();
+		expect(container.querySelector(".battle-map-header")).toBeInTheDocument();
+		expect(container.querySelector(".map-container")).toBeInTheDocument();
+		expect(container.querySelector(".toggle-button")).toBeInTheDocument();
+	});
 
-  it('toggle button has correct class', () => {
-    render(<BattleMap mapUrl="test.jpg" />);
+	it("has correct CSS classes for empty state", () => {
+		const { container } = render(<BattleMap mapUrl={null} />);
 
-    const button = screen.getByRole('button');
-    expect(button).toHaveClass('toggle-button');
-  });
+		expect(container.querySelector(".battle-map")).toBeInTheDocument();
+		expect(container.querySelector(".map-container")).toBeInTheDocument();
+		expect(container.querySelector(".empty-map-state")).toBeInTheDocument();
+	});
+
+	it("toggle button has correct class", () => {
+		render(<BattleMap mapUrl="test.jpg" />);
+
+		const button = screen.getByRole("button");
+		expect(button).toHaveClass("toggle-button");
+	});
 });

--- a/frontend/src/components/BattleMap.tsx
+++ b/frontend/src/components/BattleMap.tsx
@@ -1,37 +1,38 @@
-import React, { useState } from 'react';
-import './BattleMap.css';
+import type React from "react";
+import { useState } from "react";
+import "./BattleMap.css";
 
 interface BattleMapProps {
-  mapUrl: string | null;
+	mapUrl: string | null;
 }
 
 const BattleMap: React.FC<BattleMapProps> = ({ mapUrl }) => {
-  const [expanded, setExpanded] = useState<boolean>(false);
-  
-  const toggleExpand = () => {
-    setExpanded(!expanded);
-  };
-  
-  return (
-    <div className={`battle-map ${expanded ? 'expanded' : ''}`}>
-      <div className="battle-map-header">
-        <h3>Battle Map</h3>
-        <button onClick={toggleExpand} className="toggle-button">
-          {expanded ? 'Minimize' : 'Expand'}
-        </button>
-      </div>
-      
-      <div className="map-container">
-        {mapUrl ? (
-          <img src={mapUrl} alt="Tactical Battle Map" />
-        ) : (
-          <div className="empty-map-state">
-            <p>No battle map available</p>
-          </div>
-        )}
-      </div>
-    </div>
-  );
+	const [expanded, setExpanded] = useState<boolean>(false);
+
+	const toggleExpand = () => {
+		setExpanded(!expanded);
+	};
+
+	return (
+		<div className={`battle-map ${expanded ? "expanded" : ""}`}>
+			<div className="battle-map-header">
+				<h3>Battle Map</h3>
+				<button type="button" onClick={toggleExpand} className="toggle-button">
+					{expanded ? "Minimize" : "Expand"}
+				</button>
+			</div>
+
+			<div className="map-container">
+				{mapUrl ? (
+					<img src={mapUrl} alt="Tactical Battle Map" />
+				) : (
+					<div className="empty-map-state">
+						<p>No battle map available</p>
+					</div>
+				)}
+			</div>
+		</div>
+	);
 };
 
 export default BattleMap;

--- a/frontend/src/components/CampaignCreation.test.tsx
+++ b/frontend/src/components/CampaignCreation.test.tsx
@@ -1,238 +1,286 @@
-import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import CampaignCreation from './CampaignCreation';
-import * as api from '../services/api';
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import * as api from "../services/api";
+import CampaignCreation from "./CampaignCreation";
 
 // Mock the API module
-vi.mock('../services/api');
+vi.mock("../services/api");
 const mockCreateCampaign = vi.mocked(api.createCampaign);
 
-describe('CampaignCreation', () => {
-  const mockOnCampaignCreated = vi.fn();
+describe("CampaignCreation", () => {
+	const mockOnCampaignCreated = vi.fn();
 
-  beforeEach(() => {
-    mockOnCampaignCreated.mockClear();
-    mockCreateCampaign.mockClear();
-  });
+	beforeEach(() => {
+		mockOnCampaignCreated.mockClear();
+		mockCreateCampaign.mockClear();
+	});
 
-  it('renders form elements correctly', () => {
-    render(<CampaignCreation onCampaignCreated={mockOnCampaignCreated} />);
+	it("renders form elements correctly", () => {
+		render(<CampaignCreation onCampaignCreated={mockOnCampaignCreated} />);
 
-    expect(screen.getByText('Create New Campaign')).toBeInTheDocument();
-    expect(screen.getByLabelText('Campaign Name')).toBeInTheDocument();
-    expect(screen.getByLabelText('Campaign Setting')).toBeInTheDocument();
-    expect(screen.getByLabelText('Campaign Tone')).toBeInTheDocument();
-    expect(screen.getByLabelText('Homebrew Rules (Optional)')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Create Campaign' })).toBeInTheDocument();
-  });
+		expect(screen.getByText("Create New Campaign")).toBeInTheDocument();
+		expect(screen.getByLabelText("Campaign Name")).toBeInTheDocument();
+		expect(screen.getByLabelText("Campaign Setting")).toBeInTheDocument();
+		expect(screen.getByLabelText("Campaign Tone")).toBeInTheDocument();
+		expect(
+			screen.getByLabelText("Homebrew Rules (Optional)"),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: "Create Campaign" }),
+		).toBeInTheDocument();
+	});
 
-  it('has default tone set to heroic', () => {
-    render(<CampaignCreation onCampaignCreated={mockOnCampaignCreated} />);
+	it("has default tone set to heroic", () => {
+		render(<CampaignCreation onCampaignCreated={mockOnCampaignCreated} />);
 
-    const toneSelect = screen.getByLabelText('Campaign Tone') as HTMLSelectElement;
-    expect(toneSelect.value).toBe('heroic');
-  });
+		const toneSelect = screen.getByLabelText(
+			"Campaign Tone",
+		) as HTMLSelectElement;
+		expect(toneSelect.value).toBe("heroic");
+	});
 
-  it('shows all tone options', () => {
-    render(<CampaignCreation onCampaignCreated={mockOnCampaignCreated} />);
+	it("shows all tone options", () => {
+		render(<CampaignCreation onCampaignCreated={mockOnCampaignCreated} />);
 
-    expect(screen.getByRole('option', { name: 'Heroic' })).toBeInTheDocument();
-    expect(screen.getByRole('option', { name: 'Gritty' })).toBeInTheDocument();
-    expect(screen.getByRole('option', { name: 'Lighthearted' })).toBeInTheDocument();
-    expect(screen.getByRole('option', { name: 'Epic' })).toBeInTheDocument();
-    expect(screen.getByRole('option', { name: 'Mysterious' })).toBeInTheDocument();
-  });
+		expect(screen.getByRole("option", { name: "Heroic" })).toBeInTheDocument();
+		expect(screen.getByRole("option", { name: "Gritty" })).toBeInTheDocument();
+		expect(
+			screen.getByRole("option", { name: "Lighthearted" }),
+		).toBeInTheDocument();
+		expect(screen.getByRole("option", { name: "Epic" })).toBeInTheDocument();
+		expect(
+			screen.getByRole("option", { name: "Mysterious" }),
+		).toBeInTheDocument();
+	});
 
-  it('updates form fields correctly', async () => {
-    
-    render(<CampaignCreation onCampaignCreated={mockOnCampaignCreated} />);
+	it("updates form fields correctly", async () => {
+		render(<CampaignCreation onCampaignCreated={mockOnCampaignCreated} />);
 
-    const nameInput = screen.getByLabelText('Campaign Name');
-    const settingInput = screen.getByLabelText('Campaign Setting');
-    const toneSelect = screen.getByLabelText('Campaign Tone');
-    const homebrewInput = screen.getByLabelText('Homebrew Rules (Optional)');
+		const nameInput = screen.getByLabelText("Campaign Name");
+		const settingInput = screen.getByLabelText("Campaign Setting");
+		const toneSelect = screen.getByLabelText("Campaign Tone");
+		const homebrewInput = screen.getByLabelText("Homebrew Rules (Optional)");
 
-    await userEvent.type(nameInput, 'The Lost Kingdom');
-    await userEvent.type(settingInput, 'A mystical realm');
-    await userEvent.selectOptions(toneSelect, 'epic');
-    await userEvent.type(homebrewInput, 'Custom rule 1\nCustom rule 2');
+		await userEvent.type(nameInput, "The Lost Kingdom");
+		await userEvent.type(settingInput, "A mystical realm");
+		await userEvent.selectOptions(toneSelect, "epic");
+		await userEvent.type(homebrewInput, "Custom rule 1\nCustom rule 2");
 
-    expect(nameInput).toHaveValue('The Lost Kingdom');
-    expect(settingInput).toHaveValue('A mystical realm');
-    expect(toneSelect).toHaveValue('epic');
-    expect(homebrewInput).toHaveValue('Custom rule 1\nCustom rule 2');
-  });
+		expect(nameInput).toHaveValue("The Lost Kingdom");
+		expect(settingInput).toHaveValue("A mystical realm");
+		expect(toneSelect).toHaveValue("epic");
+		expect(homebrewInput).toHaveValue("Custom rule 1\nCustom rule 2");
+	});
 
-  it('shows validation error for empty required fields', async () => {
-    render(<CampaignCreation onCampaignCreated={mockOnCampaignCreated} />);
+	it("shows validation error for empty required fields", async () => {
+		render(<CampaignCreation onCampaignCreated={mockOnCampaignCreated} />);
 
-    const submitButton = screen.getByRole('button', { name: 'Create Campaign' });
-    await userEvent.click(submitButton);
+		const submitButton = screen.getByRole("button", {
+			name: "Create Campaign",
+		});
+		await userEvent.click(submitButton);
 
-    // The form should not call the API when validation fails
-    expect(mockCreateCampaign).not.toHaveBeenCalled();
-  });
+		// The form should not call the API when validation fails
+		expect(mockCreateCampaign).not.toHaveBeenCalled();
+	});
 
-  it('shows validation error when only name is provided', async () => {
-    render(<CampaignCreation onCampaignCreated={mockOnCampaignCreated} />);
+	it("shows validation error when only name is provided", async () => {
+		render(<CampaignCreation onCampaignCreated={mockOnCampaignCreated} />);
 
-    const nameInput = screen.getByLabelText('Campaign Name');
-    await userEvent.type(nameInput, 'Test Campaign');
+		const nameInput = screen.getByLabelText("Campaign Name");
+		await userEvent.type(nameInput, "Test Campaign");
 
-    const submitButton = screen.getByRole('button', { name: 'Create Campaign' });
-    await userEvent.click(submitButton);
+		const submitButton = screen.getByRole("button", {
+			name: "Create Campaign",
+		});
+		await userEvent.click(submitButton);
 
-    // The form should not call the API when validation fails
-    expect(mockCreateCampaign).not.toHaveBeenCalled();
-  });
+		// The form should not call the API when validation fails
+		expect(mockCreateCampaign).not.toHaveBeenCalled();
+	});
 
-  it('shows validation error when only setting is provided', async () => {
-    render(<CampaignCreation onCampaignCreated={mockOnCampaignCreated} />);
+	it("shows validation error when only setting is provided", async () => {
+		render(<CampaignCreation onCampaignCreated={mockOnCampaignCreated} />);
 
-    const settingInput = screen.getByLabelText('Campaign Setting');
-    await userEvent.type(settingInput, 'Test Setting');
+		const settingInput = screen.getByLabelText("Campaign Setting");
+		await userEvent.type(settingInput, "Test Setting");
 
-    const submitButton = screen.getByRole('button', { name: 'Create Campaign' });
-    await userEvent.click(submitButton);
+		const submitButton = screen.getByRole("button", {
+			name: "Create Campaign",
+		});
+		await userEvent.click(submitButton);
 
-    // The form should not call the API when validation fails
-    expect(mockCreateCampaign).not.toHaveBeenCalled();
-  });
+		// The form should not call the API when validation fails
+		expect(mockCreateCampaign).not.toHaveBeenCalled();
+	});
 
-  it('successfully creates campaign with valid data', async () => {
-    
-    const mockCampaign = { id: '1', name: 'Test Campaign' };
-    mockCreateCampaign.mockResolvedValue(mockCampaign as any);
+	it("successfully creates campaign with valid data", async () => {
+		const mockCampaign = {
+			id: "1",
+			name: "Test Campaign",
+			setting: "A mystical realm",
+			tone: "heroic",
+			homebrew_rules: [],
+			characters: [],
+		};
+		mockCreateCampaign.mockResolvedValue(mockCampaign);
 
-    render(<CampaignCreation onCampaignCreated={mockOnCampaignCreated} />);
+		render(<CampaignCreation onCampaignCreated={mockOnCampaignCreated} />);
 
-    const nameInput = screen.getByLabelText('Campaign Name');
-    const settingInput = screen.getByLabelText('Campaign Setting');
+		const nameInput = screen.getByLabelText("Campaign Name");
+		const settingInput = screen.getByLabelText("Campaign Setting");
 
-    await userEvent.type(nameInput, 'The Lost Kingdom');
-    await userEvent.type(settingInput, 'A mystical realm');
+		await userEvent.type(nameInput, "The Lost Kingdom");
+		await userEvent.type(settingInput, "A mystical realm");
 
-    const submitButton = screen.getByRole('button', { name: 'Create Campaign' });
-    await userEvent.click(submitButton);
+		const submitButton = screen.getByRole("button", {
+			name: "Create Campaign",
+		});
+		await userEvent.click(submitButton);
 
-    await waitFor(() => {
-      expect(mockCreateCampaign).toHaveBeenCalledWith({
-        name: 'The Lost Kingdom',
-        setting: 'A mystical realm',
-        tone: 'heroic',
-        homebrew_rules: []
-      });
-    });
+		await waitFor(() => {
+			expect(mockCreateCampaign).toHaveBeenCalledWith({
+				name: "The Lost Kingdom",
+				setting: "A mystical realm",
+				tone: "heroic",
+				homebrew_rules: [],
+			});
+		});
 
-    await waitFor(() => {
-      expect(mockOnCampaignCreated).toHaveBeenCalledWith(mockCampaign);
-    });
-  });
+		await waitFor(() => {
+			expect(mockOnCampaignCreated).toHaveBeenCalledWith(mockCampaign);
+		});
+	});
 
-  it('parses homebrew rules correctly', async () => {
-    
-    const mockCampaign = { id: '1', name: 'Test Campaign' };
-    mockCreateCampaign.mockResolvedValue(mockCampaign as any);
+	it("parses homebrew rules correctly", async () => {
+		const mockCampaign = {
+			id: "1",
+			name: "Test Campaign",
+			setting: "Test Setting",
+			tone: "heroic",
+			homebrew_rules: ["Rule 1", "Rule 2", "Rule 3"],
+			characters: [],
+		};
+		mockCreateCampaign.mockResolvedValue(mockCampaign);
 
-    render(<CampaignCreation onCampaignCreated={mockOnCampaignCreated} />);
+		render(<CampaignCreation onCampaignCreated={mockOnCampaignCreated} />);
 
-    const nameInput = screen.getByLabelText('Campaign Name');
-    const settingInput = screen.getByLabelText('Campaign Setting');
-    const homebrewInput = screen.getByLabelText('Homebrew Rules (Optional)');
+		const nameInput = screen.getByLabelText("Campaign Name");
+		const settingInput = screen.getByLabelText("Campaign Setting");
+		const homebrewInput = screen.getByLabelText("Homebrew Rules (Optional)");
 
-    await userEvent.type(nameInput, 'Test Campaign');
-    await userEvent.type(settingInput, 'Test Setting');
-    await userEvent.type(homebrewInput, 'Rule 1\n\nRule 2\n   \nRule 3   ');
+		await userEvent.type(nameInput, "Test Campaign");
+		await userEvent.type(settingInput, "Test Setting");
+		await userEvent.type(homebrewInput, "Rule 1\n\nRule 2\n   \nRule 3   ");
 
-    const submitButton = screen.getByRole('button', { name: 'Create Campaign' });
-    await userEvent.click(submitButton);
+		const submitButton = screen.getByRole("button", {
+			name: "Create Campaign",
+		});
+		await userEvent.click(submitButton);
 
-    await waitFor(() => {
-      expect(mockCreateCampaign).toHaveBeenCalledWith({
-        name: 'Test Campaign',
-        setting: 'Test Setting',
-        tone: 'heroic',
-        homebrew_rules: ['Rule 1', 'Rule 2', 'Rule 3']
-      });
-    });
-  });
+		await waitFor(() => {
+			expect(mockCreateCampaign).toHaveBeenCalledWith({
+				name: "Test Campaign",
+				setting: "Test Setting",
+				tone: "heroic",
+				homebrew_rules: ["Rule 1", "Rule 2", "Rule 3"],
+			});
+		});
+	});
 
-  it('shows loading state during submission', async () => {
-    
-    let resolvePromise: (value: any) => void;
-    const promise = new Promise(resolve => { resolvePromise = resolve; });
-    mockCreateCampaign.mockReturnValue(promise);
+	it("shows loading state during submission", async () => {
+		let resolvePromise: ((value: unknown) => void) | undefined;
+		const promise = new Promise((resolve) => {
+			resolvePromise = resolve;
+		});
+		mockCreateCampaign.mockReturnValue(promise);
 
-    render(<CampaignCreation onCampaignCreated={mockOnCampaignCreated} />);
+		render(<CampaignCreation onCampaignCreated={mockOnCampaignCreated} />);
 
-    const nameInput = screen.getByLabelText('Campaign Name');
-    const settingInput = screen.getByLabelText('Campaign Setting');
+		const nameInput = screen.getByLabelText("Campaign Name");
+		const settingInput = screen.getByLabelText("Campaign Setting");
 
-    await userEvent.type(nameInput, 'Test Campaign');
-    await userEvent.type(settingInput, 'Test Setting');
+		await userEvent.type(nameInput, "Test Campaign");
+		await userEvent.type(settingInput, "Test Setting");
 
-    const submitButton = screen.getByRole('button', { name: 'Create Campaign' });
-    await userEvent.click(submitButton);
+		const submitButton = screen.getByRole("button", {
+			name: "Create Campaign",
+		});
+		await userEvent.click(submitButton);
 
-    expect(screen.getByText('Creating...')).toBeInTheDocument();
-    expect(submitButton).toBeDisabled();
-    expect(nameInput).toBeDisabled();
-    expect(settingInput).toBeDisabled();
+		expect(screen.getByText("Creating...")).toBeInTheDocument();
+		expect(submitButton).toBeDisabled();
+		expect(nameInput).toBeDisabled();
+		expect(settingInput).toBeDisabled();
 
-    // Resolve the promise to clean up
-    resolvePromise!({ id: '1', name: 'Test Campaign' });
-  });
+		// Resolve the promise to clean up
+		resolvePromise?.({ id: "1", name: "Test Campaign" });
+	});
 
-  it('handles API errors gracefully', async () => {
-    
-    mockCreateCampaign.mockRejectedValue(new Error('API Error'));
+	it("handles API errors gracefully", async () => {
+		mockCreateCampaign.mockRejectedValue(new Error("API Error"));
 
-    render(<CampaignCreation onCampaignCreated={mockOnCampaignCreated} />);
+		render(<CampaignCreation onCampaignCreated={mockOnCampaignCreated} />);
 
-    const nameInput = screen.getByLabelText('Campaign Name');
-    const settingInput = screen.getByLabelText('Campaign Setting');
+		const nameInput = screen.getByLabelText("Campaign Name");
+		const settingInput = screen.getByLabelText("Campaign Setting");
 
-    await userEvent.type(nameInput, 'Test Campaign');
-    await userEvent.type(settingInput, 'Test Setting');
+		await userEvent.type(nameInput, "Test Campaign");
+		await userEvent.type(settingInput, "Test Setting");
 
-    const submitButton = screen.getByRole('button', { name: 'Create Campaign' });
-    await userEvent.click(submitButton);
+		const submitButton = screen.getByRole("button", {
+			name: "Create Campaign",
+		});
+		await userEvent.click(submitButton);
 
-    await waitFor(() => {
-      expect(screen.getByText('Failed to create campaign. Please try again.')).toBeInTheDocument();
-    });
+		await waitFor(() => {
+			expect(
+				screen.getByText("Failed to create campaign. Please try again."),
+			).toBeInTheDocument();
+		});
 
-    expect(mockOnCampaignCreated).not.toHaveBeenCalled();
-  });
+		expect(mockOnCampaignCreated).not.toHaveBeenCalled();
+	});
 
-  it('clears error message when submitting again', async () => {
-    
-    
-    // First submission - error
-    mockCreateCampaign.mockRejectedValueOnce(new Error('API Error'));
-    
-    render(<CampaignCreation onCampaignCreated={mockOnCampaignCreated} />);
+	it("clears error message when submitting again", async () => {
+		// First submission - error
+		mockCreateCampaign.mockRejectedValueOnce(new Error("API Error"));
 
-    const nameInput = screen.getByLabelText('Campaign Name');
-    const settingInput = screen.getByLabelText('Campaign Setting');
+		render(<CampaignCreation onCampaignCreated={mockOnCampaignCreated} />);
 
-    await userEvent.type(nameInput, 'Test Campaign');
-    await userEvent.type(settingInput, 'Test Setting');
+		const nameInput = screen.getByLabelText("Campaign Name");
+		const settingInput = screen.getByLabelText("Campaign Setting");
 
-    const submitButton = screen.getByRole('button', { name: 'Create Campaign' });
-    await userEvent.click(submitButton);
+		await userEvent.type(nameInput, "Test Campaign");
+		await userEvent.type(settingInput, "Test Setting");
 
-    await waitFor(() => {
-      expect(screen.getByText('Failed to create campaign. Please try again.')).toBeInTheDocument();
-    });
+		const submitButton = screen.getByRole("button", {
+			name: "Create Campaign",
+		});
+		await userEvent.click(submitButton);
 
-    // Second submission - success
-    mockCreateCampaign.mockResolvedValueOnce({ id: '1', name: 'Test Campaign' } as any);
-    await userEvent.click(submitButton);
+		await waitFor(() => {
+			expect(
+				screen.getByText("Failed to create campaign. Please try again."),
+			).toBeInTheDocument();
+		});
 
-    await waitFor(() => {
-      expect(screen.queryByText('Failed to create campaign. Please try again.')).not.toBeInTheDocument();
-    });
-  });
+		// Second submission - success
+		mockCreateCampaign.mockResolvedValueOnce({
+			id: "1",
+			name: "Test Campaign",
+			setting: "Test Setting",
+			tone: "heroic",
+			homebrew_rules: [],
+			characters: [],
+		});
+		await userEvent.click(submitButton);
+
+		await waitFor(() => {
+			expect(
+				screen.queryByText("Failed to create campaign. Please try again."),
+			).not.toBeInTheDocument();
+		});
+	});
 });

--- a/frontend/src/components/CampaignCreation.tsx
+++ b/frontend/src/components/CampaignCreation.tsx
@@ -1,125 +1,126 @@
-import React, { useState } from 'react';
-import { createCampaign, CampaignCreateRequest } from '../services/api';
-import './CampaignCreation.css';
+import { useState } from "react";
+import type React from "react";
+import {
+	type Campaign,
+	type CampaignCreateRequest,
+	createCampaign,
+} from "../services/api";
+import "./CampaignCreation.css";
 
 interface CampaignCreationProps {
-  onCampaignCreated: (campaign: any) => void;
+	onCampaignCreated: (campaign: Campaign) => void;
 }
 
-const CampaignCreation: React.FC<CampaignCreationProps> = ({ onCampaignCreated }) => {
-  const [campaignName, setCampaignName] = useState('');
-  const [setting, setSetting] = useState('');
-  const [tone, setTone] = useState('heroic');
-  const [homebrewRules, setHomebrewRules] = useState('');
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+const CampaignCreation: React.FC<CampaignCreationProps> = ({
+	onCampaignCreated,
+}) => {
+	const [campaignName, setCampaignName] = useState("");
+	const [setting, setSetting] = useState("");
+	const [tone, setTone] = useState("heroic");
+	const [homebrewRules, setHomebrewRules] = useState("");
+	const [isSubmitting, setIsSubmitting] = useState(false);
+	const [error, setError] = useState<string | null>(null);
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
+	const handleSubmit = async (e: React.FormEvent) => {
+		e.preventDefault();
 
-    if (!campaignName || !setting) {
-      setError('Campaign name and setting are required.');
-      return;
-    }
+		if (!campaignName || !setting) {
+			setError("Campaign name and setting are required.");
+			return;
+		}
 
-    setIsSubmitting(true);
-    setError(null);
+		setIsSubmitting(true);
+		setError(null);
 
-    try {
-      // Parse homebrew rules into array
-      const homebrewRulesList = homebrewRules
-        .split('\n')
-        .map(rule => rule.trim())
-        .filter(rule => rule !== '');
+		try {
+			// Parse homebrew rules into array
+			const homebrewRulesList = homebrewRules
+				.split("\n")
+				.map((rule) => rule.trim())
+				.filter((rule) => rule !== "");
 
-      const campaignData: CampaignCreateRequest = {
-        name: campaignName,
-        setting,
-        tone,
-        homebrew_rules: homebrewRulesList
-      };
+			const campaignData: CampaignCreateRequest = {
+				name: campaignName,
+				setting,
+				tone,
+				homebrew_rules: homebrewRulesList,
+			};
 
-      const result = await createCampaign(campaignData);
-      onCampaignCreated(result);
-    } catch (err) {
-      setError('Failed to create campaign. Please try again.');
-      console.error('Error creating campaign:', err);
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
+			const result = await createCampaign(campaignData);
+			onCampaignCreated(result);
+		} catch (err) {
+			setError("Failed to create campaign. Please try again.");
+			console.error("Error creating campaign:", err);
+		} finally {
+			setIsSubmitting(false);
+		}
+	};
 
-  return (
-    <div className="campaign-creation">
-      <h2>Create New Campaign</h2>
+	return (
+		<div className="campaign-creation">
+			<h2>Create New Campaign</h2>
 
-      {error && (
-        <div className="error-message">{error}</div>
-      )}
+			{error && <div className="error-message">{error}</div>}
 
-      <form onSubmit={handleSubmit}>
-        <div className="form-group">
-          <label htmlFor="campaign-name">Campaign Name</label>
-          <input
-            id="campaign-name"
-            type="text"
-            value={campaignName}
-            onChange={(e) => setCampaignName(e.target.value)}
-            placeholder="Enter campaign name"
-            disabled={isSubmitting}
-            required
-          />
-        </div>
+			<form onSubmit={handleSubmit}>
+				<div className="form-group">
+					<label htmlFor="campaign-name">Campaign Name</label>
+					<input
+						id="campaign-name"
+						type="text"
+						value={campaignName}
+						onChange={(e) => setCampaignName(e.target.value)}
+						placeholder="Enter campaign name"
+						disabled={isSubmitting}
+						required
+					/>
+				</div>
 
-        <div className="form-group">
-          <label htmlFor="setting">Campaign Setting</label>
-          <textarea
-            id="setting"
-            value={setting}
-            onChange={(e) => setSetting(e.target.value)}
-            placeholder="Describe your campaign setting (e.g., medieval fantasy world, cyberpunk future)"
-            disabled={isSubmitting}
-            required
-          />
-        </div>
+				<div className="form-group">
+					<label htmlFor="setting">Campaign Setting</label>
+					<textarea
+						id="setting"
+						value={setting}
+						onChange={(e) => setSetting(e.target.value)}
+						placeholder="Describe your campaign setting (e.g., medieval fantasy world, cyberpunk future)"
+						disabled={isSubmitting}
+						required
+					/>
+				</div>
 
-        <div className="form-group">
-          <label htmlFor="tone">Campaign Tone</label>
-          <select
-            id="tone"
-            value={tone}
-            onChange={(e) => setTone(e.target.value)}
-            disabled={isSubmitting}
-          >
-            <option value="heroic">Heroic</option>
-            <option value="gritty">Gritty</option>
-            <option value="lighthearted">Lighthearted</option>
-            <option value="epic">Epic</option>
-            <option value="mysterious">Mysterious</option>
-          </select>
-        </div>
+				<div className="form-group">
+					<label htmlFor="tone">Campaign Tone</label>
+					<select
+						id="tone"
+						value={tone}
+						onChange={(e) => setTone(e.target.value)}
+						disabled={isSubmitting}
+					>
+						<option value="heroic">Heroic</option>
+						<option value="gritty">Gritty</option>
+						<option value="lighthearted">Lighthearted</option>
+						<option value="epic">Epic</option>
+						<option value="mysterious">Mysterious</option>
+					</select>
+				</div>
 
-        <div className="form-group">
-          <label htmlFor="homebrew-rules">Homebrew Rules (Optional)</label>
-          <textarea
-            id="homebrew-rules"
-            value={homebrewRules}
-            onChange={(e) => setHomebrewRules(e.target.value)}
-            placeholder="Enter any homebrew rules (one per line)"
-            disabled={isSubmitting}
-          />
-        </div>
+				<div className="form-group">
+					<label htmlFor="homebrew-rules">Homebrew Rules (Optional)</label>
+					<textarea
+						id="homebrew-rules"
+						value={homebrewRules}
+						onChange={(e) => setHomebrewRules(e.target.value)}
+						placeholder="Enter any homebrew rules (one per line)"
+						disabled={isSubmitting}
+					/>
+				</div>
 
-        <button
-          type="submit"
-          className="create-button"
-          disabled={isSubmitting}
-        >
-          {isSubmitting ? 'Creating...' : 'Create Campaign'}
-        </button>
-      </form>
-    </div>
-  );
+				<button type="submit" className="create-button" disabled={isSubmitting}>
+					{isSubmitting ? "Creating..." : "Create Campaign"}
+				</button>
+			</form>
+		</div>
+	);
 };
 
 export default CampaignCreation;

--- a/frontend/src/components/CharacterSheet.test.tsx
+++ b/frontend/src/components/CharacterSheet.test.tsx
@@ -1,164 +1,168 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import CharacterSheet from './CharacterSheet';
-import { Character } from '../services/api';
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import type { Character } from "../services/api";
+import CharacterSheet from "./CharacterSheet";
 
-describe('CharacterSheet', () => {
-  const mockCharacter: Character = {
-    id: '1',
-    name: 'Aragorn',
-    race: 'Human',
-    class: 'Ranger',
-    level: 5,
-    abilities: {
-      strength: 16,
-      dexterity: 14,
-      constitution: 15,
-      intelligence: 12,
-      wisdom: 18,
-      charisma: 10,
-    },
-    hitPoints: {
-      current: 45,
-      maximum: 50,
-    },
-    inventory: [
-      { name: 'Longsword', quantity: 1 },
-      { name: 'Health Potion', quantity: 3 },
-    ],
-  };
+describe("CharacterSheet", () => {
+	const mockCharacter: Character = {
+		id: "1",
+		name: "Aragorn",
+		race: "Human",
+		class: "Ranger",
+		level: 5,
+		abilities: {
+			strength: 16,
+			dexterity: 14,
+			constitution: 15,
+			intelligence: 12,
+			wisdom: 18,
+			charisma: 10,
+		},
+		hitPoints: {
+			current: 45,
+			maximum: 50,
+		},
+		inventory: [
+			{ name: "Longsword", quantity: 1 },
+			{ name: "Health Potion", quantity: 3 },
+		],
+	};
 
-  it('renders character basic information', () => {
-    render(<CharacterSheet character={mockCharacter} />);
+	it("renders character basic information", () => {
+		render(<CharacterSheet character={mockCharacter} />);
 
-    expect(screen.getByText('Aragorn')).toBeInTheDocument();
-    expect(screen.getByText('Level 5 Human Ranger')).toBeInTheDocument();
-  });
+		expect(screen.getByText("Aragorn")).toBeInTheDocument();
+		expect(screen.getByText("Level 5 Human Ranger")).toBeInTheDocument();
+	});
 
-  it('renders hit points correctly', () => {
-    render(<CharacterSheet character={mockCharacter} />);
+	it("renders hit points correctly", () => {
+		render(<CharacterSheet character={mockCharacter} />);
 
-    expect(screen.getByText('Hit Points')).toBeInTheDocument();
-    expect(screen.getByText('45 / 50')).toBeInTheDocument();
-  });
+		expect(screen.getByText("Hit Points")).toBeInTheDocument();
+		expect(screen.getByText("45 / 50")).toBeInTheDocument();
+	});
 
-  it('renders armor class', () => {
-    render(<CharacterSheet character={mockCharacter} />);
+	it("renders armor class", () => {
+		render(<CharacterSheet character={mockCharacter} />);
 
-    expect(screen.getByText('Armor Class')).toBeInTheDocument();
-    // Find the armor class value specifically by looking for it in the stats area
-    const armorClassSection = screen.getByText('Armor Class').closest('.armor-class');
-    expect(armorClassSection).toHaveTextContent('10');
-  });
+		expect(screen.getByText("Armor Class")).toBeInTheDocument();
+		// Find the armor class value specifically by looking for it in the stats area
+		const armorClassSection = screen
+			.getByText("Armor Class")
+			.closest(".armor-class");
+		expect(armorClassSection).toHaveTextContent("10");
+	});
 
-  it('renders all ability scores', () => {
-    render(<CharacterSheet character={mockCharacter} />);
+	it("renders all ability scores", () => {
+		render(<CharacterSheet character={mockCharacter} />);
 
-    expect(screen.getByText('STR')).toBeInTheDocument();
-    expect(screen.getByText('DEX')).toBeInTheDocument();
-    expect(screen.getByText('CON')).toBeInTheDocument();
-    expect(screen.getByText('INT')).toBeInTheDocument();
-    expect(screen.getByText('WIS')).toBeInTheDocument();
-    expect(screen.getByText('CHA')).toBeInTheDocument();
+		expect(screen.getByText("STR")).toBeInTheDocument();
+		expect(screen.getByText("DEX")).toBeInTheDocument();
+		expect(screen.getByText("CON")).toBeInTheDocument();
+		expect(screen.getByText("INT")).toBeInTheDocument();
+		expect(screen.getByText("WIS")).toBeInTheDocument();
+		expect(screen.getByText("CHA")).toBeInTheDocument();
 
-    // Check ability scores in their respective ability sections
-    const abilities = screen.getByText('Abilities').closest('.abilities');
-    expect(abilities).toHaveTextContent('16'); // STR
-    expect(abilities).toHaveTextContent('14'); // DEX
-    expect(abilities).toHaveTextContent('15'); // CON
-    expect(abilities).toHaveTextContent('12'); // INT
-    expect(abilities).toHaveTextContent('18'); // WIS
-  });
+		// Check ability scores in their respective ability sections
+		const abilities = screen.getByText("Abilities").closest(".abilities");
+		expect(abilities).toHaveTextContent("16"); // STR
+		expect(abilities).toHaveTextContent("14"); // DEX
+		expect(abilities).toHaveTextContent("15"); // CON
+		expect(abilities).toHaveTextContent("12"); // INT
+		expect(abilities).toHaveTextContent("18"); // WIS
+	});
 
-  it('calculates and displays ability modifiers correctly', () => {
-    render(<CharacterSheet character={mockCharacter} />);
+	it("calculates and displays ability modifiers correctly", () => {
+		render(<CharacterSheet character={mockCharacter} />);
 
-    // Check for specific modifiers in the abilities section
-    const abilitiesSection = screen.getByText('Abilities').closest('.abilities');
-    
-    // STR 16 -> +3
-    expect(abilitiesSection).toHaveTextContent('+3');
-    // WIS 18 -> +4
-    expect(abilitiesSection).toHaveTextContent('+4');
-    // INT 12 -> +1
-    expect(abilitiesSection).toHaveTextContent('+1');
-    // CHA 10 -> +0
-    expect(abilitiesSection).toHaveTextContent('+0');
-    // DEX 14 and CON 15 both give +2, so we expect to find +2 twice
-    const plusTwoElements = screen.getAllByText('+2');
-    expect(plusTwoElements).toHaveLength(2);
-  });
+		// Check for specific modifiers in the abilities section
+		const abilitiesSection = screen
+			.getByText("Abilities")
+			.closest(".abilities");
 
-  it('calculates negative ability modifiers correctly', () => {
-    const lowStatCharacter: Character = {
-      ...mockCharacter,
-      abilities: {
-        strength: 8, // -1
-        dexterity: 6, // -2
-        constitution: 4, // -3
-        intelligence: 10,
-        wisdom: 10,
-        charisma: 10,
-      },
-    };
+		// STR 16 -> +3
+		expect(abilitiesSection).toHaveTextContent("+3");
+		// WIS 18 -> +4
+		expect(abilitiesSection).toHaveTextContent("+4");
+		// INT 12 -> +1
+		expect(abilitiesSection).toHaveTextContent("+1");
+		// CHA 10 -> +0
+		expect(abilitiesSection).toHaveTextContent("+0");
+		// DEX 14 and CON 15 both give +2, so we expect to find +2 twice
+		const plusTwoElements = screen.getAllByText("+2");
+		expect(plusTwoElements).toHaveLength(2);
+	});
 
-    render(<CharacterSheet character={lowStatCharacter} />);
+	it("calculates negative ability modifiers correctly", () => {
+		const lowStatCharacter: Character = {
+			...mockCharacter,
+			abilities: {
+				strength: 8, // -1
+				dexterity: 6, // -2
+				constitution: 4, // -3
+				intelligence: 10,
+				wisdom: 10,
+				charisma: 10,
+			},
+		};
 
-    expect(screen.getByText('-1')).toBeInTheDocument();
-    expect(screen.getByText('-2')).toBeInTheDocument();
-    expect(screen.getByText('-3')).toBeInTheDocument();
-  });
+		render(<CharacterSheet character={lowStatCharacter} />);
 
-  it('renders inventory items', () => {
-    render(<CharacterSheet character={mockCharacter} />);
+		expect(screen.getByText("-1")).toBeInTheDocument();
+		expect(screen.getByText("-2")).toBeInTheDocument();
+		expect(screen.getByText("-3")).toBeInTheDocument();
+	});
 
-    expect(screen.getByText('Inventory')).toBeInTheDocument();
-    expect(screen.getByText('Longsword')).toBeInTheDocument();
-    expect(screen.getByText('Health Potion')).toBeInTheDocument();
-    expect(screen.getByText('x3')).toBeInTheDocument(); // Quantity for Health Potion
-  });
+	it("renders inventory items", () => {
+		render(<CharacterSheet character={mockCharacter} />);
 
-  it('does not show quantity for items with quantity 1', () => {
-    render(<CharacterSheet character={mockCharacter} />);
+		expect(screen.getByText("Inventory")).toBeInTheDocument();
+		expect(screen.getByText("Longsword")).toBeInTheDocument();
+		expect(screen.getByText("Health Potion")).toBeInTheDocument();
+		expect(screen.getByText("x3")).toBeInTheDocument(); // Quantity for Health Potion
+	});
 
-    const longsword = screen.getByText('Longsword').closest('.inventory-item');
-    expect(longsword).not.toHaveTextContent('x1');
-  });
+	it("does not show quantity for items with quantity 1", () => {
+		render(<CharacterSheet character={mockCharacter} />);
 
-  it('handles empty inventory', () => {
-    const characterWithEmptyInventory: Character = {
-      ...mockCharacter,
-      inventory: [],
-    };
+		const longsword = screen.getByText("Longsword").closest(".inventory-item");
+		expect(longsword).not.toHaveTextContent("x1");
+	});
 
-    render(<CharacterSheet character={characterWithEmptyInventory} />);
+	it("handles empty inventory", () => {
+		const characterWithEmptyInventory: Character = {
+			...mockCharacter,
+			inventory: [],
+		};
 
-    expect(screen.getByText('No items in inventory')).toBeInTheDocument();
-  });
+		render(<CharacterSheet character={characterWithEmptyInventory} />);
 
-  it('handles undefined inventory', () => {
-    const characterWithUndefinedInventory: Character = {
-      ...mockCharacter,
-      inventory: undefined as any,
-    };
+		expect(screen.getByText("No items in inventory")).toBeInTheDocument();
+	});
 
-    render(<CharacterSheet character={characterWithUndefinedInventory} />);
+	it("handles undefined inventory", () => {
+		const characterWithUndefinedInventory: Character = {
+			...mockCharacter,
+			inventory: undefined as unknown as unknown[],
+		};
 
-    expect(screen.getByText('No items in inventory')).toBeInTheDocument();
-  });
+		render(<CharacterSheet character={characterWithUndefinedInventory} />);
 
-  it('has proper CSS classes for styling', () => {
-    const { container } = render(<CharacterSheet character={mockCharacter} />);
+		expect(screen.getByText("No items in inventory")).toBeInTheDocument();
+	});
 
-    expect(container.querySelector('.character-sheet')).toBeInTheDocument();
-    expect(container.querySelector('.character-header')).toBeInTheDocument();
-    expect(container.querySelector('.abilities-grid')).toBeInTheDocument();
-    expect(container.querySelector('.inventory-list')).toBeInTheDocument();
-  });
+	it("has proper CSS classes for styling", () => {
+		const { container } = render(<CharacterSheet character={mockCharacter} />);
 
-  it('displays abilities section header', () => {
-    render(<CharacterSheet character={mockCharacter} />);
+		expect(container.querySelector(".character-sheet")).toBeInTheDocument();
+		expect(container.querySelector(".character-header")).toBeInTheDocument();
+		expect(container.querySelector(".abilities-grid")).toBeInTheDocument();
+		expect(container.querySelector(".inventory-list")).toBeInTheDocument();
+	});
 
-    expect(screen.getByText('Abilities')).toBeInTheDocument();
-  });
+	it("displays abilities section header", () => {
+		render(<CharacterSheet character={mockCharacter} />);
+
+		expect(screen.getByText("Abilities")).toBeInTheDocument();
+	});
 });

--- a/frontend/src/components/CharacterSheet.tsx
+++ b/frontend/src/components/CharacterSheet.tsx
@@ -1,92 +1,115 @@
-import React from 'react';
-import { Character } from '../services/api';
-import './CharacterSheet.css';
+import type React from "react";
+import type { Character } from "../services/api";
+import "./CharacterSheet.css";
 
 interface CharacterSheetProps {
-  character: Character;
+	character: Character;
 }
 
 const CharacterSheet: React.FC<CharacterSheetProps> = ({ character }) => {
-  // Helper function to calculate ability modifier
-  const getAbilityModifier = (score: number): string => {
-    const modifier = Math.floor((score - 10) / 2);
-    return modifier >= 0 ? `+${modifier}` : modifier.toString();
-  };
+	// Helper function to calculate ability modifier
+	const getAbilityModifier = (score: number): string => {
+		const modifier = Math.floor((score - 10) / 2);
+		return modifier >= 0 ? `+${modifier}` : modifier.toString();
+	};
 
-  return (
-    <div className="character-sheet">
-      <div className="character-header">
-        <h2>{character.name}</h2>
-        <div className="character-basics">
-          <div>Level {character.level} {character.race} {character.class}</div>
-        </div>
-      </div>
-      
-      <div className="character-stats">
-        <div className="hit-points">
-          <div className="stat-label">Hit Points</div>
-          <div className="stat-value">{character.hitPoints.current} / {character.hitPoints.maximum}</div>
-        </div>
-        
-        <div className="armor-class">
-          <div className="stat-label">Armor Class</div>
-          <div className="stat-value">10</div> {/* Would be calculated from equipment and stats */}
-        </div>
-      </div>
-      
-      <div className="abilities">
-        <h3>Abilities</h3>
-        <div className="abilities-grid">
-          <div className="ability">
-            <div className="ability-name">STR</div>
-            <div className="ability-score">{character.abilities.strength}</div>
-            <div className="ability-mod">{getAbilityModifier(character.abilities.strength)}</div>
-          </div>
-          <div className="ability">
-            <div className="ability-name">DEX</div>
-            <div className="ability-score">{character.abilities.dexterity}</div>
-            <div className="ability-mod">{getAbilityModifier(character.abilities.dexterity)}</div>
-          </div>
-          <div className="ability">
-            <div className="ability-name">CON</div>
-            <div className="ability-score">{character.abilities.constitution}</div>
-            <div className="ability-mod">{getAbilityModifier(character.abilities.constitution)}</div>
-          </div>
-          <div className="ability">
-            <div className="ability-name">INT</div>
-            <div className="ability-score">{character.abilities.intelligence}</div>
-            <div className="ability-mod">{getAbilityModifier(character.abilities.intelligence)}</div>
-          </div>
-          <div className="ability">
-            <div className="ability-name">WIS</div>
-            <div className="ability-score">{character.abilities.wisdom}</div>
-            <div className="ability-mod">{getAbilityModifier(character.abilities.wisdom)}</div>
-          </div>
-          <div className="ability">
-            <div className="ability-name">CHA</div>
-            <div className="ability-score">{character.abilities.charisma}</div>
-            <div className="ability-mod">{getAbilityModifier(character.abilities.charisma)}</div>
-          </div>
-        </div>
-      </div>
-      
-      <div className="inventory">
-        <h3>Inventory</h3>
-        <ul className="inventory-list">
-          {character.inventory && character.inventory.length > 0 ? (
-            character.inventory.map((item, index) => (
-              <li key={index} className="inventory-item">
-                <span className="item-name">{item.name}</span>
-                {item.quantity > 1 && <span className="item-quantity">x{item.quantity}</span>}
-              </li>
-            ))
-          ) : (
-            <li className="empty-inventory">No items in inventory</li>
-          )}
-        </ul>
-      </div>
-    </div>
-  );
+	return (
+		<div className="character-sheet">
+			<div className="character-header">
+				<h2>{character.name}</h2>
+				<div className="character-basics">
+					<div>
+						Level {character.level} {character.race} {character.class}
+					</div>
+				</div>
+			</div>
+
+			<div className="character-stats">
+				<div className="hit-points">
+					<div className="stat-label">Hit Points</div>
+					<div className="stat-value">
+						{character.hitPoints.current} / {character.hitPoints.maximum}
+					</div>
+				</div>
+
+				<div className="armor-class">
+					<div className="stat-label">Armor Class</div>
+					<div className="stat-value">10</div>{" "}
+					{/* Would be calculated from equipment and stats */}
+				</div>
+			</div>
+
+			<div className="abilities">
+				<h3>Abilities</h3>
+				<div className="abilities-grid">
+					<div className="ability">
+						<div className="ability-name">STR</div>
+						<div className="ability-score">{character.abilities.strength}</div>
+						<div className="ability-mod">
+							{getAbilityModifier(character.abilities.strength)}
+						</div>
+					</div>
+					<div className="ability">
+						<div className="ability-name">DEX</div>
+						<div className="ability-score">{character.abilities.dexterity}</div>
+						<div className="ability-mod">
+							{getAbilityModifier(character.abilities.dexterity)}
+						</div>
+					</div>
+					<div className="ability">
+						<div className="ability-name">CON</div>
+						<div className="ability-score">
+							{character.abilities.constitution}
+						</div>
+						<div className="ability-mod">
+							{getAbilityModifier(character.abilities.constitution)}
+						</div>
+					</div>
+					<div className="ability">
+						<div className="ability-name">INT</div>
+						<div className="ability-score">
+							{character.abilities.intelligence}
+						</div>
+						<div className="ability-mod">
+							{getAbilityModifier(character.abilities.intelligence)}
+						</div>
+					</div>
+					<div className="ability">
+						<div className="ability-name">WIS</div>
+						<div className="ability-score">{character.abilities.wisdom}</div>
+						<div className="ability-mod">
+							{getAbilityModifier(character.abilities.wisdom)}
+						</div>
+					</div>
+					<div className="ability">
+						<div className="ability-name">CHA</div>
+						<div className="ability-score">{character.abilities.charisma}</div>
+						<div className="ability-mod">
+							{getAbilityModifier(character.abilities.charisma)}
+						</div>
+					</div>
+				</div>
+			</div>
+
+			<div className="inventory">
+				<h3>Inventory</h3>
+				<ul className="inventory-list">
+					{character.inventory && character.inventory.length > 0 ? (
+						character.inventory.map((item, index) => (
+							<li key={`${item.name}-${index}`} className="inventory-item">
+								<span className="item-name">{item.name}</span>
+								{item.quantity > 1 && (
+									<span className="item-quantity">x{item.quantity}</span>
+								)}
+							</li>
+						))
+					) : (
+						<li className="empty-inventory">No items in inventory</li>
+					)}
+				</ul>
+			</div>
+		</div>
+	);
 };
 
 export default CharacterSheet;

--- a/frontend/src/components/ChatBox.test.tsx
+++ b/frontend/src/components/ChatBox.test.tsx
@@ -1,154 +1,155 @@
-import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import ChatBox from './ChatBox';
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import ChatBox from "./ChatBox";
 
 // Mock scrollIntoView
-Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
-  value: vi.fn(),
-  writable: true,
+Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+	value: vi.fn(),
+	writable: true,
 });
 
-describe('ChatBox', () => {
-  const mockOnSendMessage = vi.fn();
-  const defaultProps = {
-    messages: [],
-    onSendMessage: mockOnSendMessage,
-    isLoading: false,
-  };
+describe("ChatBox", () => {
+	const mockOnSendMessage = vi.fn();
+	const defaultProps = {
+		messages: [],
+		onSendMessage: mockOnSendMessage,
+		isLoading: false,
+	};
 
-  beforeEach(() => {
-    mockOnSendMessage.mockClear();
-  });
+	beforeEach(() => {
+		mockOnSendMessage.mockClear();
+	});
 
-  it('renders empty chat box', () => {
-    render(<ChatBox {...defaultProps} />);
-    expect(screen.getByPlaceholderText('What do you want to do?')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Send' })).toBeInTheDocument();
-  });
+	it("renders empty chat box", () => {
+		render(<ChatBox {...defaultProps} />);
+		expect(
+			screen.getByPlaceholderText("What do you want to do?"),
+		).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Send" })).toBeInTheDocument();
+	});
 
-  it('displays messages correctly', () => {
-    const messages = [
-      { text: 'Hello player!', sender: 'dm' as const },
-      { text: 'Hello DM!', sender: 'player' as const },
-    ];
+	it("displays messages correctly", () => {
+		const messages = [
+			{ text: "Hello player!", sender: "dm" as const },
+			{ text: "Hello DM!", sender: "player" as const },
+		];
 
-    render(<ChatBox {...defaultProps} messages={messages} />);
+		render(<ChatBox {...defaultProps} messages={messages} />);
 
-    expect(screen.getByText('Hello player!')).toBeInTheDocument();
-    expect(screen.getByText('Hello DM!')).toBeInTheDocument();
-    expect(screen.getByText('Dungeon Master')).toBeInTheDocument();
-    expect(screen.getByText('You')).toBeInTheDocument();
-  });
+		expect(screen.getByText("Hello player!")).toBeInTheDocument();
+		expect(screen.getByText("Hello DM!")).toBeInTheDocument();
+		expect(screen.getByText("Dungeon Master")).toBeInTheDocument();
+		expect(screen.getByText("You")).toBeInTheDocument();
+	});
 
-  it('handles message input and submission', async () => {
-    
-    render(<ChatBox {...defaultProps} />);
+	it("handles message input and submission", async () => {
+		render(<ChatBox {...defaultProps} />);
 
-    const input = screen.getByPlaceholderText('What do you want to do?');
-    const sendButton = screen.getByRole('button', { name: 'Send' });
+		const input = screen.getByPlaceholderText("What do you want to do?");
+		const sendButton = screen.getByRole("button", { name: "Send" });
 
-    // Type a message
-    await userEvent.type(input, 'I want to explore the castle');
-    expect(input).toHaveValue('I want to explore the castle');
+		// Type a message
+		await userEvent.type(input, "I want to explore the castle");
+		expect(input).toHaveValue("I want to explore the castle");
 
-    // Submit the message
-    await userEvent.click(sendButton);
+		// Submit the message
+		await userEvent.click(sendButton);
 
-    expect(mockOnSendMessage).toHaveBeenCalledWith('I want to explore the castle');
-    expect(input).toHaveValue(''); // Input should be cleared
-  });
+		expect(mockOnSendMessage).toHaveBeenCalledWith(
+			"I want to explore the castle",
+		);
+		expect(input).toHaveValue(""); // Input should be cleared
+	});
 
-  it('handles form submission with Enter key', async () => {
-    
-    render(<ChatBox {...defaultProps} />);
+	it("handles form submission with Enter key", async () => {
+		render(<ChatBox {...defaultProps} />);
 
-    const input = screen.getByPlaceholderText('What do you want to do?');
+		const input = screen.getByPlaceholderText("What do you want to do?");
 
-    await userEvent.type(input, 'Look around');
-    await userEvent.keyboard('{Enter}');
+		await userEvent.type(input, "Look around");
+		await userEvent.keyboard("{Enter}");
 
-    expect(mockOnSendMessage).toHaveBeenCalledWith('Look around');
-    expect(input).toHaveValue('');
-  });
+		expect(mockOnSendMessage).toHaveBeenCalledWith("Look around");
+		expect(input).toHaveValue("");
+	});
 
-  it('disables input and button when loading', () => {
-    render(<ChatBox {...defaultProps} isLoading={true} />);
+	it("disables input and button when loading", () => {
+		render(<ChatBox {...defaultProps} isLoading={true} />);
 
-    const input = screen.getByPlaceholderText('What do you want to do?');
-    const sendButton = screen.getByRole('button', { name: 'Send' });
+		const input = screen.getByPlaceholderText("What do you want to do?");
+		const sendButton = screen.getByRole("button", { name: "Send" });
 
-    expect(input).toBeDisabled();
-    expect(sendButton).toBeDisabled();
-  });
+		expect(input).toBeDisabled();
+		expect(sendButton).toBeDisabled();
+	});
 
-  it('disables send button when input is empty', () => {
-    render(<ChatBox {...defaultProps} />);
+	it("disables send button when input is empty", () => {
+		render(<ChatBox {...defaultProps} />);
 
-    const sendButton = screen.getByRole('button', { name: 'Send' });
-    expect(sendButton).toBeDisabled();
-  });
+		const sendButton = screen.getByRole("button", { name: "Send" });
+		expect(sendButton).toBeDisabled();
+	});
 
-  it('disables send button when input is only whitespace', async () => {
-    
-    render(<ChatBox {...defaultProps} />);
+	it("disables send button when input is only whitespace", async () => {
+		render(<ChatBox {...defaultProps} />);
 
-    const input = screen.getByPlaceholderText('What do you want to do?');
-    const sendButton = screen.getByRole('button', { name: 'Send' });
+		const input = screen.getByPlaceholderText("What do you want to do?");
+		const sendButton = screen.getByRole("button", { name: "Send" });
 
-    await userEvent.type(input, '   ');
-    expect(sendButton).toBeDisabled();
-  });
+		await userEvent.type(input, "   ");
+		expect(sendButton).toBeDisabled();
+	});
 
-  it('does not submit empty or whitespace-only messages', async () => {
-    
-    render(<ChatBox {...defaultProps} />);
+	it("does not submit empty or whitespace-only messages", async () => {
+		render(<ChatBox {...defaultProps} />);
 
-    const input = screen.getByPlaceholderText('What do you want to do?');
+		const input = screen.getByPlaceholderText("What do you want to do?");
 
-    // Try to submit empty message
-    await userEvent.keyboard('{Enter}');
-    expect(mockOnSendMessage).not.toHaveBeenCalled();
+		// Try to submit empty message
+		await userEvent.keyboard("{Enter}");
+		expect(mockOnSendMessage).not.toHaveBeenCalled();
 
-    // Try to submit whitespace-only message
-    await userEvent.type(input, '   ');
-    await userEvent.keyboard('{Enter}');
-    expect(mockOnSendMessage).not.toHaveBeenCalled();
-  });
+		// Try to submit whitespace-only message
+		await userEvent.type(input, "   ");
+		await userEvent.keyboard("{Enter}");
+		expect(mockOnSendMessage).not.toHaveBeenCalled();
+	});
 
-  it('shows loading indicator when loading', () => {
-    render(<ChatBox {...defaultProps} isLoading={true} />);
+	it("shows loading indicator when loading", () => {
+		render(<ChatBox {...defaultProps} isLoading={true} />);
 
-    expect(screen.getByText('Dungeon Master')).toBeInTheDocument();
-    // Look for the typing indicator by its class
-    expect(document.querySelector('.typing-indicator')).toBeInTheDocument();
-  });
+		expect(screen.getByText("Dungeon Master")).toBeInTheDocument();
+		// Look for the typing indicator by its class
+		expect(document.querySelector(".typing-indicator")).toBeInTheDocument();
+	});
 
-  it('prevents submission when loading', async () => {
-    
-    render(<ChatBox {...defaultProps} isLoading={true} />);
+	it("prevents submission when loading", async () => {
+		render(<ChatBox {...defaultProps} isLoading={true} />);
 
-    const input = screen.getByPlaceholderText('What do you want to do?');
-    
-    // Input should be disabled, but let's test the form anyway
-    fireEvent.change(input, { target: { value: 'test message' } });
-    fireEvent.submit(input.closest('form')!);
+		const input = screen.getByPlaceholderText("What do you want to do?");
 
-    expect(mockOnSendMessage).not.toHaveBeenCalled();
-  });
+		// Input should be disabled, but let's test the form anyway
+		fireEvent.change(input, { target: { value: "test message" } });
+		fireEvent.submit(input.closest("form") as HTMLFormElement);
 
-  it('applies correct CSS classes to messages', () => {
-    const messages = [
-      { text: 'DM message', sender: 'dm' as const },
-      { text: 'Player message', sender: 'player' as const },
-    ];
+		expect(mockOnSendMessage).not.toHaveBeenCalled();
+	});
 
-    render(<ChatBox {...defaultProps} messages={messages} />);
+	it("applies correct CSS classes to messages", () => {
+		const messages = [
+			{ text: "DM message", sender: "dm" as const },
+			{ text: "Player message", sender: "player" as const },
+		];
 
-    const dmMessage = screen.getByText('DM message').closest('.message');
-    const playerMessage = screen.getByText('Player message').closest('.message');
+		render(<ChatBox {...defaultProps} messages={messages} />);
 
-    expect(dmMessage).toHaveClass('dm-message');
-    expect(playerMessage).toHaveClass('player-message');
-  });
+		const dmMessage = screen.getByText("DM message").closest(".message");
+		const playerMessage = screen
+			.getByText("Player message")
+			.closest(".message");
+
+		expect(dmMessage).toHaveClass("dm-message");
+		expect(playerMessage).toHaveClass("player-message");
+	});
 });

--- a/frontend/src/components/ChatBox.tsx
+++ b/frontend/src/components/ChatBox.tsx
@@ -1,81 +1,88 @@
-import React, { useState, useRef, useEffect } from 'react';
-import './ChatBox.css';
+import type React from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import "./ChatBox.css";
 
 interface ChatMessage {
-  text: string;
-  sender: 'player' | 'dm';
+	text: string;
+	sender: "player" | "dm";
 }
 
 interface ChatBoxProps {
-  messages: ChatMessage[];
-  onSendMessage: (message: string) => void;
-  isLoading: boolean;
+	messages: ChatMessage[];
+	onSendMessage: (message: string) => void;
+	isLoading: boolean;
 }
 
-const ChatBox: React.FC<ChatBoxProps> = ({ messages, onSendMessage, isLoading }) => {
-  const [input, setInput] = useState<string>('');
-  const messagesEndRef = useRef<HTMLDivElement>(null);
+const ChatBox: React.FC<ChatBoxProps> = ({
+	messages,
+	onSendMessage,
+	isLoading,
+}) => {
+	const [input, setInput] = useState<string>("");
+	const messagesEndRef = useRef<HTMLDivElement>(null);
 
-  // Scroll to bottom when messages change
-  useEffect(() => {
-    scrollToBottom();
-  }, [messages]);
+	// Scroll to bottom when messages change
+	const scrollToBottom = useCallback(() => {
+		messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+	}, []);
 
-  const scrollToBottom = () => {
-    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
-  };
+	useEffect(() => {
+		if (messages.length) {
+			scrollToBottom();
+		}
+	}, [messages, scrollToBottom]);
 
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    if (input.trim() && !isLoading) {
-      onSendMessage(input);
-      setInput('');
-    }
-  };
+	const handleSubmit = (e: React.FormEvent) => {
+		e.preventDefault();
+		if (input.trim() && !isLoading) {
+			onSendMessage(input);
+			setInput("");
+		}
+	};
 
-  return (
-    <div className="chat-box">
-      <div className="messages-container">
-        {messages.map((message, index) => (
-          <div 
-            key={index} 
-            className={`message ${message.sender === 'player' ? 'player-message' : 'dm-message'}`}
-          >
-            <div className="message-sender">
-              {message.sender === 'player' ? 'You' : 'Dungeon Master'}
-            </div>
-            <div className="message-text">{message.text}</div>
-          </div>
-        ))}
-        {isLoading && (
-          <div className="message dm-message">
-            <div className="message-sender">Dungeon Master</div>
-            <div className="message-text loading">
-              <div className="typing-indicator">
-                <span></span>
-                <span></span>
-                <span></span>
-              </div>
-            </div>
-          </div>
-        )}
-        <div ref={messagesEndRef} />
-      </div>
-      
-      <form className="input-form" onSubmit={handleSubmit}>
-        <input
-          type="text"
-          value={input}
-          onChange={(e) => setInput(e.target.value)}
-          placeholder="What do you want to do?"
-          disabled={isLoading}
-        />
-        <button type="submit" disabled={isLoading || !input.trim()}>
-          Send
-        </button>
-      </form>
-    </div>
-  );
+	return (
+		<div className="chat-box">
+			<div className="messages-container">
+				{messages.map((message, index) => (
+					<div
+						key={`${message.text}-${index}`}
+						className={`message ${message.sender === "player" ? "player-message" : "dm-message"}`}
+					>
+						<div className="message-sender">
+							{message.sender === "player" ? "You" : "Dungeon Master"}
+						</div>
+						<div className="message-text">{message.text}</div>
+					</div>
+				))}
+				{isLoading && (
+					<div className="message dm-message">
+						<div className="message-sender">Dungeon Master</div>
+						<div className="message-text loading">
+							<div className="typing-indicator">
+								<span />
+								<span />
+								<span />
+							</div>
+						</div>
+					</div>
+				)}
+				<div ref={messagesEndRef} />
+			</div>
+
+			<form className="input-form" onSubmit={handleSubmit}>
+				<input
+					type="text"
+					value={input}
+					onChange={(e) => setInput(e.target.value)}
+					placeholder="What do you want to do?"
+					disabled={isLoading}
+				/>
+				<button type="submit" disabled={isLoading || !input.trim()}>
+					Send
+				</button>
+			</form>
+		</div>
+	);
 };
 
 export default ChatBox;

--- a/frontend/src/components/GameInterface.test.tsx
+++ b/frontend/src/components/GameInterface.test.tsx
@@ -1,265 +1,306 @@
-import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import GameInterface from './GameInterface';
-import { Character, Campaign } from '../services/api';
-import * as api from '../services/api';
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import * as api from "../services/api";
+import type { Campaign, Character } from "../services/api";
+import GameInterface from "./GameInterface";
 
 // Mock the API module
-vi.mock('../services/api');
+vi.mock("../services/api");
 const mockSendPlayerInput = vi.mocked(api.sendPlayerInput);
 
 // Mock child components
-vi.mock('./ChatBox', () => ({
-  default: ({ messages, onSendMessage, isLoading }: any) => (
-    <div data-testid="chat-box">
-      <div data-testid="messages">
-        {messages.map((msg: any, idx: number) => (
-          <div key={idx}>{msg.text}</div>
-        ))}
-      </div>
-      <button onClick={() => onSendMessage('test message')} disabled={isLoading}>
-        Send Message
-      </button>
-    </div>
-  ),
+vi.mock("./ChatBox", () => ({
+	default: ({
+		messages,
+		onSendMessage,
+		isLoading,
+	}: {
+		messages: Array<{ text: string }>;
+		onSendMessage: (msg: string) => void;
+		isLoading: boolean;
+	}) => (
+		<div data-testid="chat-box">
+			<div data-testid="messages">
+				{messages.map((msg, idx) => (
+					<div key={`${msg.text}-${idx}`}>{msg.text}</div>
+				))}
+			</div>
+			<button
+				type="button"
+				onClick={() => onSendMessage("test message")}
+				disabled={isLoading}
+			>
+				Send Message
+			</button>
+		</div>
+	),
 }));
 
-vi.mock('./CharacterSheet', () => ({
-  default: ({ character }: any) => (
-    <div data-testid="character-sheet">{character.name}</div>
-  ),
+vi.mock("./CharacterSheet", () => ({
+	default: ({ character }: { character: Character }) => (
+		<div data-testid="character-sheet">{character.name}</div>
+	),
 }));
 
-vi.mock('./ImageDisplay', () => ({
-  default: ({ imageUrl }: any) => (
-    <div data-testid="image-display">{imageUrl || 'No image'}</div>
-  ),
+vi.mock("./ImageDisplay", () => ({
+	default: ({ imageUrl }: { imageUrl: string | null }) => (
+		<div data-testid="image-display">{imageUrl || "No image"}</div>
+	),
 }));
 
-vi.mock('./BattleMap', () => ({
-  default: ({ mapUrl }: any) => (
-    <div data-testid="battle-map">{mapUrl || 'No map'}</div>
-  ),
+vi.mock("./BattleMap", () => ({
+	default: ({ mapUrl }: { mapUrl: string | null }) => (
+		<div data-testid="battle-map">{mapUrl || "No map"}</div>
+	),
 }));
 
-describe('GameInterface', () => {
-  const mockCharacter: Character = {
-    id: '1',
-    name: 'Aragorn',
-    race: 'Human',
-    class: 'Ranger',
-    level: 5,
-    abilities: {
-      strength: 16,
-      dexterity: 14,
-      constitution: 15,
-      intelligence: 12,
-      wisdom: 18,
-      charisma: 10,
-    },
-    hitPoints: {
-      current: 45,
-      maximum: 50,
-    },
-    inventory: [],
-  };
+describe("GameInterface", () => {
+	const mockCharacter: Character = {
+		id: "1",
+		name: "Aragorn",
+		race: "Human",
+		class: "Ranger",
+		level: 5,
+		abilities: {
+			strength: 16,
+			dexterity: 14,
+			constitution: 15,
+			intelligence: 12,
+			wisdom: 18,
+			charisma: 10,
+		},
+		hitPoints: {
+			current: 45,
+			maximum: 50,
+		},
+		inventory: [],
+	};
 
-  const mockCampaign: Campaign = {
-    id: '1',
-    name: 'The Lost Kingdom',
-    setting: 'Medieval Fantasy',
-    tone: 'heroic',
-    homebrew_rules: [],
-    characters: ['1'],
-    world_description: 'A mystical realm awaits.',
-  };
+	const mockCampaign: Campaign = {
+		id: "1",
+		name: "The Lost Kingdom",
+		setting: "Medieval Fantasy",
+		tone: "heroic",
+		homebrew_rules: [],
+		characters: ["1"],
+		world_description: "A mystical realm awaits.",
+	};
 
-  beforeEach(() => {
-    mockSendPlayerInput.mockClear();
-  });
+	beforeEach(() => {
+		mockSendPlayerInput.mockClear();
+	});
 
-  it('renders all child components', () => {
-    render(<GameInterface character={mockCharacter} campaign={mockCampaign} />);
+	it("renders all child components", () => {
+		render(<GameInterface character={mockCharacter} campaign={mockCampaign} />);
 
-    expect(screen.getByTestId('character-sheet')).toBeInTheDocument();
-    expect(screen.getByTestId('chat-box')).toBeInTheDocument();
-    expect(screen.getByTestId('image-display')).toBeInTheDocument();
-  });
+		expect(screen.getByTestId("character-sheet")).toBeInTheDocument();
+		expect(screen.getByTestId("chat-box")).toBeInTheDocument();
+		expect(screen.getByTestId("image-display")).toBeInTheDocument();
+	});
 
-  it('displays welcome message on mount', () => {
-    render(<GameInterface character={mockCharacter} campaign={mockCampaign} />);
+	it("displays welcome message on mount", () => {
+		render(<GameInterface character={mockCharacter} campaign={mockCampaign} />);
 
-    const expectedMessage = 'Welcome, Aragorn! Your adventure in The Lost Kingdom begins now. A mystical realm awaits.';
-    expect(screen.getByText(expectedMessage)).toBeInTheDocument();
-  });
+		const expectedMessage =
+			"Welcome, Aragorn! Your adventure in The Lost Kingdom begins now. A mystical realm awaits.";
+		expect(screen.getByText(expectedMessage)).toBeInTheDocument();
+	});
 
-  it('displays welcome message without world description', () => {
-    const campaignWithoutDescription = { ...mockCampaign, world_description: undefined };
-    render(<GameInterface character={mockCharacter} campaign={campaignWithoutDescription} />);
+	it("displays welcome message without world description", () => {
+		const campaignWithoutDescription = {
+			...mockCampaign,
+			world_description: undefined,
+		};
+		render(
+			<GameInterface
+				character={mockCharacter}
+				campaign={campaignWithoutDescription}
+			/>,
+		);
 
-    expect(screen.getByText(/Welcome, Aragorn! Your adventure in The Lost Kingdom begins now\./)).toBeInTheDocument();
-  });
+		expect(
+			screen.getByText(
+				/Welcome, Aragorn! Your adventure in The Lost Kingdom begins now\./,
+			),
+		).toBeInTheDocument();
+	});
 
-  it('shows initial world art if available', () => {
-    const campaignWithArt = {
-      ...mockCampaign,
-      world_art: { image_url: 'https://example.com/world.jpg' },
-    };
-    render(<GameInterface character={mockCharacter} campaign={campaignWithArt} />);
+	it("shows initial world art if available", () => {
+		const campaignWithArt = {
+			...mockCampaign,
+			world_art: { image_url: "https://example.com/world.jpg" },
+		};
+		render(
+			<GameInterface character={mockCharacter} campaign={campaignWithArt} />,
+		);
 
-    expect(screen.getByText('https://example.com/world.jpg')).toBeInTheDocument();
-  });
+		expect(
+			screen.getByText("https://example.com/world.jpg"),
+		).toBeInTheDocument();
+	});
 
-  it('handles player input and API response', async () => {
-    const mockResponse = {
-      message: 'You see a castle in the distance.',
-      images: ['https://example.com/castle.jpg'],
-      state_updates: {},
-      combat_updates: null,
-    };
-    mockSendPlayerInput.mockResolvedValue(mockResponse);
+	it("handles player input and API response", async () => {
+		const mockResponse = {
+			message: "You see a castle in the distance.",
+			images: ["https://example.com/castle.jpg"],
+			state_updates: {},
+			combat_updates: null,
+		};
+		mockSendPlayerInput.mockResolvedValue(mockResponse);
 
-    render(<GameInterface character={mockCharacter} campaign={mockCampaign} />);
+		render(<GameInterface character={mockCharacter} campaign={mockCampaign} />);
 
-    const sendButton = screen.getByText('Send Message');
-    await userEvent.click(sendButton);
+		const sendButton = screen.getByText("Send Message");
+		await userEvent.click(sendButton);
 
-    await waitFor(() => {
-      expect(mockSendPlayerInput).toHaveBeenCalledWith({
-        message: 'test message',
-        character_id: '1',
-        campaign_id: '1',
-      });
-    });
+		await waitFor(() => {
+			expect(mockSendPlayerInput).toHaveBeenCalledWith({
+				message: "test message",
+				character_id: "1",
+				campaign_id: "1",
+			});
+		});
 
-    await waitFor(() => {
-      expect(screen.getByText('You see a castle in the distance.')).toBeInTheDocument();
-    });
-  });
+		await waitFor(() => {
+			expect(
+				screen.getByText("You see a castle in the distance."),
+			).toBeInTheDocument();
+		});
+	});
 
-  it('updates image when response includes new image', async () => {
-    const mockResponse = {
-      message: 'Response with image',
-      images: ['https://example.com/new-image.jpg'],
-      state_updates: {},
-      combat_updates: null,
-    };
-    mockSendPlayerInput.mockResolvedValue(mockResponse);
+	it("updates image when response includes new image", async () => {
+		const mockResponse = {
+			message: "Response with image",
+			images: ["https://example.com/new-image.jpg"],
+			state_updates: {},
+			combat_updates: null,
+		};
+		mockSendPlayerInput.mockResolvedValue(mockResponse);
 
-    render(<GameInterface character={mockCharacter} campaign={mockCampaign} />);
+		render(<GameInterface character={mockCharacter} campaign={mockCampaign} />);
 
-    const sendButton = screen.getByText('Send Message');
-    await userEvent.click(sendButton);
+		const sendButton = screen.getByText("Send Message");
+		await userEvent.click(sendButton);
 
-    await waitFor(() => {
-      expect(screen.getByText('https://example.com/new-image.jpg')).toBeInTheDocument();
-    });
-  });
+		await waitFor(() => {
+			expect(
+				screen.getByText("https://example.com/new-image.jpg"),
+			).toBeInTheDocument();
+		});
+	});
 
-  it('activates combat mode when combat updates received', async () => {
-    const mockResponse = {
-      message: 'Combat begins!',
-      images: [],
-      state_updates: {},
-      combat_updates: {
-        status: 'active',
-        map_url: 'https://example.com/battle-map.jpg',
-      },
-    };
-    mockSendPlayerInput.mockResolvedValue(mockResponse);
+	it("activates combat mode when combat updates received", async () => {
+		const mockResponse = {
+			message: "Combat begins!",
+			images: [],
+			state_updates: {},
+			combat_updates: {
+				status: "active",
+				map_url: "https://example.com/battle-map.jpg",
+			},
+		};
+		mockSendPlayerInput.mockResolvedValue(mockResponse);
 
-    render(<GameInterface character={mockCharacter} campaign={mockCampaign} />);
+		render(<GameInterface character={mockCharacter} campaign={mockCampaign} />);
 
-    // Battle map should not be visible initially
-    expect(screen.queryByTestId('battle-map')).not.toBeInTheDocument();
+		// Battle map should not be visible initially
+		expect(screen.queryByTestId("battle-map")).not.toBeInTheDocument();
 
-    const sendButton = screen.getByText('Send Message');
-    await userEvent.click(sendButton);
+		const sendButton = screen.getByText("Send Message");
+		await userEvent.click(sendButton);
 
-    await waitFor(() => {
-      expect(screen.getByTestId('battle-map')).toBeInTheDocument();
-      expect(screen.getByText('https://example.com/battle-map.jpg')).toBeInTheDocument();
-    });
-  });
+		await waitFor(() => {
+			expect(screen.getByTestId("battle-map")).toBeInTheDocument();
+			expect(
+				screen.getByText("https://example.com/battle-map.jpg"),
+			).toBeInTheDocument();
+		});
+	});
 
-  it('handles API errors gracefully', async () => {
-    mockSendPlayerInput.mockRejectedValue(new Error('API Error'));
+	it("handles API errors gracefully", async () => {
+		mockSendPlayerInput.mockRejectedValue(new Error("API Error"));
 
-    render(<GameInterface character={mockCharacter} campaign={mockCampaign} />);
+		render(<GameInterface character={mockCharacter} campaign={mockCampaign} />);
 
-    const sendButton = screen.getByText('Send Message');
-    await userEvent.click(sendButton);
+		const sendButton = screen.getByText("Send Message");
+		await userEvent.click(sendButton);
 
-    await waitFor(() => {
-      expect(screen.getByText('Something went wrong. Please try again.')).toBeInTheDocument();
-    });
-  });
+		await waitFor(() => {
+			expect(
+				screen.getByText("Something went wrong. Please try again."),
+			).toBeInTheDocument();
+		});
+	});
 
-  it('shows loading state during API call', async () => {
-    let resolvePromise: (value: any) => void;
-    const promise = new Promise(resolve => { resolvePromise = resolve; });
-    mockSendPlayerInput.mockReturnValue(promise);
+	it("shows loading state during API call", async () => {
+		let resolvePromise: ((value: unknown) => void) | undefined;
+		const promise = new Promise((resolve) => {
+			resolvePromise = resolve;
+		});
+		mockSendPlayerInput.mockReturnValue(promise);
 
-    render(<GameInterface character={mockCharacter} campaign={mockCampaign} />);
+		render(<GameInterface character={mockCharacter} campaign={mockCampaign} />);
 
-    const sendButton = screen.getByText('Send Message');
-    await userEvent.click(sendButton);
+		const sendButton = screen.getByText("Send Message");
+		await userEvent.click(sendButton);
 
-    // Should be disabled during loading
-    expect(sendButton).toBeDisabled();
+		// Should be disabled during loading
+		expect(sendButton).toBeDisabled();
 
-    // Resolve to clean up
-    resolvePromise!({
-      message: 'Response',
-      images: [],
-      state_updates: {},
-      combat_updates: null,
-    });
-  });
+		// Resolve to clean up
+		resolvePromise?.({
+			message: "Response",
+			images: [],
+			state_updates: {},
+			combat_updates: null,
+		});
+	});
 
-  it('deactivates combat mode when combat is no longer active', async () => {
-    // First activate combat
-    const activateCombatResponse = {
-      message: 'Combat begins!',
-      images: [],
-      state_updates: {},
-      combat_updates: { status: 'active', map_url: 'battle.jpg' },
-    };
-    mockSendPlayerInput.mockResolvedValueOnce(activateCombatResponse);
+	it("deactivates combat mode when combat is no longer active", async () => {
+		// First activate combat
+		const activateCombatResponse = {
+			message: "Combat begins!",
+			images: [],
+			state_updates: {},
+			combat_updates: { status: "active", map_url: "battle.jpg" },
+		};
+		mockSendPlayerInput.mockResolvedValueOnce(activateCombatResponse);
 
-    render(<GameInterface character={mockCharacter} campaign={mockCampaign} />);
+		render(<GameInterface character={mockCharacter} campaign={mockCampaign} />);
 
-    const sendButton = screen.getByText('Send Message');
-    await userEvent.click(sendButton);
+		const sendButton = screen.getByText("Send Message");
+		await userEvent.click(sendButton);
 
-    await waitFor(() => {
-      expect(screen.getByTestId('battle-map')).toBeInTheDocument();
-    });
+		await waitFor(() => {
+			expect(screen.getByTestId("battle-map")).toBeInTheDocument();
+		});
 
-    // Then deactivate combat
-    const deactivateCombatResponse = {
-      message: 'Combat ends!',
-      images: [],
-      state_updates: {},
-      combat_updates: { status: 'inactive' },
-    };
-    mockSendPlayerInput.mockResolvedValueOnce(deactivateCombatResponse);
+		// Then deactivate combat
+		const deactivateCombatResponse = {
+			message: "Combat ends!",
+			images: [],
+			state_updates: {},
+			combat_updates: { status: "inactive" },
+		};
+		mockSendPlayerInput.mockResolvedValueOnce(deactivateCombatResponse);
 
-    await userEvent.click(sendButton);
+		await userEvent.click(sendButton);
 
-    await waitFor(() => {
-      expect(screen.queryByTestId('battle-map')).not.toBeInTheDocument();
-    });
-  });
+		await waitFor(() => {
+			expect(screen.queryByTestId("battle-map")).not.toBeInTheDocument();
+		});
+	});
 
-  it('has correct CSS structure', () => {
-    const { container } = render(<GameInterface character={mockCharacter} campaign={mockCampaign} />);
+	it("has correct CSS structure", () => {
+		const { container } = render(
+			<GameInterface character={mockCharacter} campaign={mockCampaign} />,
+		);
 
-    expect(container.querySelector('.game-interface')).toBeInTheDocument();
-    expect(container.querySelector('.game-container')).toBeInTheDocument();
-    expect(container.querySelector('.left-panel')).toBeInTheDocument();
-    expect(container.querySelector('.center-panel')).toBeInTheDocument();
-    expect(container.querySelector('.right-panel')).toBeInTheDocument();
-  });
+		expect(container.querySelector(".game-interface")).toBeInTheDocument();
+		expect(container.querySelector(".game-container")).toBeInTheDocument();
+		expect(container.querySelector(".left-panel")).toBeInTheDocument();
+		expect(container.querySelector(".center-panel")).toBeInTheDocument();
+		expect(container.querySelector(".right-panel")).toBeInTheDocument();
+	});
 });

--- a/frontend/src/components/GameInterface.tsx
+++ b/frontend/src/components/GameInterface.tsx
@@ -1,104 +1,121 @@
-import React, { useState, useEffect, useRef } from 'react';
-import { sendPlayerInput, GameResponse, Character, Campaign } from '../services/api';
-import ChatBox from './ChatBox';
-import CharacterSheet from './CharacterSheet';
-import ImageDisplay from './ImageDisplay';
-import BattleMap from './BattleMap';
-import './GameInterface.css';
+import type React from "react";
+import { useEffect, useRef, useState } from "react";
+import {
+	type Campaign,
+	type Character,
+	type GameResponse,
+	sendPlayerInput,
+} from "../services/api";
+import BattleMap from "./BattleMap";
+import CharacterSheet from "./CharacterSheet";
+import ChatBox from "./ChatBox";
+import ImageDisplay from "./ImageDisplay";
+import "./GameInterface.css";
 
 interface GameInterfaceProps {
-  character: Character;
-  campaign: Campaign;
+	character: Character;
+	campaign: Campaign;
 }
 
-const GameInterface: React.FC<GameInterfaceProps> = ({ character, campaign }) => {
-  const [messages, setMessages] = useState<Array<{text: string, sender: 'player' | 'dm'}>>([]);
-  const [loading, setLoading] = useState<boolean>(false);
-  const [currentImage, setCurrentImage] = useState<string | null>(null);
-  const [battleMapUrl, setBattleMapUrl] = useState<string | null>(null);
-  const [combatActive, setCombatActive] = useState<boolean>(false);
+const GameInterface: React.FC<GameInterfaceProps> = ({
+	character,
+	campaign,
+}) => {
+	const [messages, setMessages] = useState<
+		Array<{ text: string; sender: "player" | "dm" }>
+	>([]);
+	const [loading, setLoading] = useState<boolean>(false);
+	const [currentImage, setCurrentImage] = useState<string | null>(null);
+	const [battleMapUrl, setBattleMapUrl] = useState<string | null>(null);
+	const [combatActive, setCombatActive] = useState<boolean>(false);
 
-  useEffect(() => {
-    // Initial welcome message
-    const welcomeMessage = `Welcome, ${character.name}! Your adventure in ${campaign.name} begins now. ${campaign.world_description || ''}`;
-    setMessages([{ text: welcomeMessage, sender: 'dm' }]);
+	useEffect(() => {
+		// Initial welcome message
+		const welcomeMessage = `Welcome, ${character.name}! Your adventure in ${campaign.name} begins now. ${campaign.world_description || ""}`;
+		setMessages([{ text: welcomeMessage, sender: "dm" }]);
 
-    // Set initial world image if available
-    if (campaign.world_art && campaign.world_art.image_url) {
-      setCurrentImage(campaign.world_art.image_url);
-    }
-  }, [character, campaign]);
+		// Set initial world image if available
+		if (campaign.world_art?.image_url) {
+			setCurrentImage(campaign.world_art.image_url);
+		}
+	}, [character, campaign]);
 
-  const handlePlayerInput = async (message: string) => {
-    // Add player message to chat
-    setMessages(prev => [...prev, { text: message, sender: 'player' }]);
-    setLoading(true);
+	const handlePlayerInput = async (message: string) => {
+		// Add player message to chat
+		setMessages((prev) => [...prev, { text: message, sender: "player" }]);
+		setLoading(true);
 
-    try {
-      // Send message to API
-      const response = await sendPlayerInput({
-        message,
-        character_id: character.id,
-        campaign_id: campaign.id
-      });
+		try {
+			// Send message to API
+			const response = await sendPlayerInput({
+				message,
+				character_id: character.id,
+				campaign_id: campaign.id,
+			});
 
-      // Add DM response to chat
-      setMessages(prev => [...prev, { text: response.message, sender: 'dm' }]);
+			// Add DM response to chat
+			setMessages((prev) => [
+				...prev,
+				{ text: response.message, sender: "dm" },
+			]);
 
-      // Update images if provided
-      if (response.images && response.images.length > 0) {
-        setCurrentImage(response.images[0]);
-      }
+			// Update images if provided
+			if (response.images && response.images.length > 0) {
+				setCurrentImage(response.images[0]);
+			}
 
-      // Handle combat updates
-      if (response.combat_updates) {
-        setCombatActive(response.combat_updates.status === 'active');
+			// Handle combat updates
+			if (response.combat_updates) {
+				setCombatActive(response.combat_updates.status === "active");
 
-        // Set battle map if available
-        if (response.combat_updates.map_url) {
-          setBattleMapUrl(response.combat_updates.map_url);
-        }
-      }
-    } catch (error) {
-      console.error('Error processing player input:', error);
-      setMessages(prev => [...prev, {
-        text: 'Something went wrong. Please try again.',
-        sender: 'dm'
-      }]);
-    } finally {
-      setLoading(false);
-    }
-  };
+				// Set battle map if available
+				if (response.combat_updates.map_url) {
+					setBattleMapUrl(response.combat_updates.map_url);
+				}
+			}
+		} catch (error) {
+			console.error("Error processing player input:", error);
+			setMessages((prev) => [
+				...prev,
+				{
+					text: "Something went wrong. Please try again.",
+					sender: "dm",
+				},
+			]);
+		} finally {
+			setLoading(false);
+		}
+	};
 
-  return (
-    <div className="game-interface">
-      <div className="game-container">
-        <div className="left-panel">
-          <CharacterSheet character={character} />
-        </div>
+	return (
+		<div className="game-interface">
+			<div className="game-container">
+				<div className="left-panel">
+					<CharacterSheet character={character} />
+				</div>
 
-        <div className="center-panel">
-          <ChatBox
-            messages={messages}
-            onSendMessage={handlePlayerInput}
-            isLoading={loading}
-          />
-        </div>
+				<div className="center-panel">
+					<ChatBox
+						messages={messages}
+						onSendMessage={handlePlayerInput}
+						isLoading={loading}
+					/>
+				</div>
 
-        <div className="right-panel">
-          <div className="image-section">
-            <ImageDisplay imageUrl={currentImage} />
-          </div>
+				<div className="right-panel">
+					<div className="image-section">
+						<ImageDisplay imageUrl={currentImage} />
+					</div>
 
-          {combatActive && (
-            <div className="battle-map-section">
-              <BattleMap mapUrl={battleMapUrl} />
-            </div>
-          )}
-        </div>
-      </div>
-    </div>
-  );
+					{combatActive && (
+						<div className="battle-map-section">
+							<BattleMap mapUrl={battleMapUrl} />
+						</div>
+					)}
+				</div>
+			</div>
+		</div>
+	);
 };
 
 export default GameInterface;

--- a/frontend/src/components/ImageDisplay.test.tsx
+++ b/frontend/src/components/ImageDisplay.test.tsx
@@ -1,44 +1,44 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import ImageDisplay from './ImageDisplay';
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import ImageDisplay from "./ImageDisplay";
 
-describe('ImageDisplay', () => {
-  it('renders image when imageUrl is provided', () => {
-    const imageUrl = 'https://example.com/test-image.jpg';
-    render(<ImageDisplay imageUrl={imageUrl} />);
+describe("ImageDisplay", () => {
+	it("renders image when imageUrl is provided", () => {
+		const imageUrl = "https://example.com/test-image.jpg";
+		render(<ImageDisplay imageUrl={imageUrl} />);
 
-    const image = screen.getByRole('img');
-    expect(image).toBeInTheDocument();
-    expect(image).toHaveAttribute('src', imageUrl);
-    expect(image).toHaveAttribute('alt', 'Game Visualization');
-  });
+		const image = screen.getByRole("img");
+		expect(image).toBeInTheDocument();
+		expect(image).toHaveAttribute("src", imageUrl);
+		expect(image).toHaveAttribute("alt", "Game Visualization");
+	});
 
-  it('renders empty state when imageUrl is null', () => {
-    render(<ImageDisplay imageUrl={null} />);
+	it("renders empty state when imageUrl is null", () => {
+		render(<ImageDisplay imageUrl={null} />);
 
-    expect(screen.getByText('No image available')).toBeInTheDocument();
-    expect(screen.queryByRole('img')).not.toBeInTheDocument();
-  });
+		expect(screen.getByText("No image available")).toBeInTheDocument();
+		expect(screen.queryByRole("img")).not.toBeInTheDocument();
+	});
 
-  it('renders empty state when imageUrl is empty string', () => {
-    render(<ImageDisplay imageUrl="" />);
+	it("renders empty state when imageUrl is empty string", () => {
+		render(<ImageDisplay imageUrl="" />);
 
-    expect(screen.getByText('No image available')).toBeInTheDocument();
-    expect(screen.queryByRole('img')).not.toBeInTheDocument();
-  });
+		expect(screen.getByText("No image available")).toBeInTheDocument();
+		expect(screen.queryByRole("img")).not.toBeInTheDocument();
+	});
 
-  it('has correct CSS classes', () => {
-    const { container } = render(<ImageDisplay imageUrl="test.jpg" />);
+	it("has correct CSS classes", () => {
+		const { container } = render(<ImageDisplay imageUrl="test.jpg" />);
 
-    expect(container.querySelector('.image-display')).toBeInTheDocument();
-    expect(container.querySelector('.image-container')).toBeInTheDocument();
-  });
+		expect(container.querySelector(".image-display")).toBeInTheDocument();
+		expect(container.querySelector(".image-container")).toBeInTheDocument();
+	});
 
-  it('has correct CSS classes for empty state', () => {
-    const { container } = render(<ImageDisplay imageUrl={null} />);
+	it("has correct CSS classes for empty state", () => {
+		const { container } = render(<ImageDisplay imageUrl={null} />);
 
-    expect(container.querySelector('.image-display')).toBeInTheDocument();
-    expect(container.querySelector('.image-container')).toBeInTheDocument();
-    expect(container.querySelector('.empty-image-state')).toBeInTheDocument();
-  });
+		expect(container.querySelector(".image-display")).toBeInTheDocument();
+		expect(container.querySelector(".image-container")).toBeInTheDocument();
+		expect(container.querySelector(".empty-image-state")).toBeInTheDocument();
+	});
 });

--- a/frontend/src/components/ImageDisplay.tsx
+++ b/frontend/src/components/ImageDisplay.tsx
@@ -1,24 +1,24 @@
-import React from 'react';
-import './ImageDisplay.css';
+import type React from "react";
+import "./ImageDisplay.css";
 
 interface ImageDisplayProps {
-  imageUrl: string | null;
+	imageUrl: string | null;
 }
 
 const ImageDisplay: React.FC<ImageDisplayProps> = ({ imageUrl }) => {
-  return (
-    <div className="image-display">
-      <div className="image-container">
-        {imageUrl ? (
-          <img src={imageUrl} alt="Game Visualization" />
-        ) : (
-          <div className="empty-image-state">
-            <p>No image available</p>
-          </div>
-        )}
-      </div>
-    </div>
-  );
+	return (
+		<div className="image-display">
+			<div className="image-container">
+				{imageUrl ? (
+					<img src={imageUrl} alt="Game Visualization" />
+				) : (
+					<div className="empty-image-state">
+						<p>No image available</p>
+					</div>
+				)}
+			</div>
+		</div>
+	);
 };
 
 export default ImageDisplay;

--- a/frontend/src/reportWebVitals.ts
+++ b/frontend/src/reportWebVitals.ts
@@ -1,15 +1,15 @@
-import { ReportHandler } from 'web-vitals';
+import type { ReportHandler } from "web-vitals";
 
 const reportWebVitals = (onPerfEntry?: ReportHandler) => {
-  if (onPerfEntry && onPerfEntry instanceof Function) {
-    import('web-vitals').then(({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {
-      getCLS(onPerfEntry);
-      getFID(onPerfEntry);
-      getFCP(onPerfEntry);
-      getLCP(onPerfEntry);
-      getTTFB(onPerfEntry);
-    });
-  }
+	if (onPerfEntry && onPerfEntry instanceof Function) {
+		import("web-vitals").then(({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {
+			getCLS(onPerfEntry);
+			getFID(onPerfEntry);
+			getFCP(onPerfEntry);
+			getLCP(onPerfEntry);
+			getTTFB(onPerfEntry);
+		});
+	}
 };
 
 export default reportWebVitals;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,152 +1,168 @@
 // API client for interacting with the backend
-import axios from 'axios';
+import axios from "axios";
 
 // Define the base API URL - would come from environment in production
-const API_BASE_URL = process.env.REACT_APP_API_URL || 'http://localhost:8000/api';
+const API_BASE_URL =
+	process.env.REACT_APP_API_URL || "http://localhost:8000/api";
 
 // Create axios instance with default config
 const apiClient = axios.create({
-  baseURL: API_BASE_URL,
-  headers: {
-    'Content-Type': 'application/json',
-  },
+	baseURL: API_BASE_URL,
+	headers: {
+		"Content-Type": "application/json",
+	},
 });
 
 // Define API interface types
 export interface CharacterCreateRequest {
-  name: string;
-  race: string;
-  character_class: string;
-  abilities: {
-    strength: number;
-    dexterity: number;
-    constitution: number;
-    intelligence: number;
-    wisdom: number;
-    charisma: number;
-  };
-  backstory?: string;
+	name: string;
+	race: string;
+	character_class: string;
+	abilities: {
+		strength: number;
+		dexterity: number;
+		constitution: number;
+		intelligence: number;
+		wisdom: number;
+		charisma: number;
+	};
+	backstory?: string;
 }
 
 export interface Character {
-  id: string;
-  name: string;
-  race: string;
-  class: string;
-  level: number;
-  abilities: {
-    strength: number;
-    dexterity: number;
-    constitution: number;
-    intelligence: number;
-    wisdom: number;
-    charisma: number;
-  };
-  hitPoints: {
-    current: number;
-    maximum: number;
-  };
-  inventory: any[];
+	id: string;
+	name: string;
+	race: string;
+	class: string;
+	level: number;
+	abilities: {
+		strength: number;
+		dexterity: number;
+		constitution: number;
+		intelligence: number;
+		wisdom: number;
+		charisma: number;
+	};
+	hitPoints: {
+		current: number;
+		maximum: number;
+	};
+	inventory: unknown[];
 }
 
 export interface Campaign {
-  id: string;
-  name: string;
-  setting: string;
-  tone: string;
-  homebrew_rules: string[];
-  characters: string[];
-  world_description?: string;
-  world_art?: any;
+	id: string;
+	name: string;
+	setting: string;
+	tone: string;
+	homebrew_rules: string[];
+	characters: string[];
+	world_description?: string;
+	world_art?: {
+		image_url: string;
+	};
 }
 
 export interface CampaignCreateRequest {
-  name: string;
-  setting: string;
-  tone?: string;
-  homebrew_rules?: string[];
+	name: string;
+	setting: string;
+	tone?: string;
+	homebrew_rules?: string[];
 }
 
 export interface PlayerInputRequest {
-  message: string;
-  character_id: string;
-  campaign_id: string;
+	message: string;
+	character_id: string;
+	campaign_id: string;
 }
 
 export interface GameResponse {
-  message: string;
-  images: string[];
-  state_updates: Record<string, any>;
-  combat_updates?: Record<string, any>;
+	message: string;
+	images: string[];
+	state_updates: Record<string, unknown>;
+	combat_updates?: Record<string, unknown>;
 }
 
 export interface ImageGenerateRequest {
-  image_type: 'character_portrait' | 'scene_illustration' | 'item_visualization';
-  details: any;
+	image_type:
+		| "character_portrait"
+		| "scene_illustration"
+		| "item_visualization";
+	details: Record<string, unknown>;
 }
 
 export interface BattleMapRequest {
-  environment: any;
-  combat_context?: any;
+	environment: Record<string, unknown>;
+	combat_context?: Record<string, unknown>;
 }
 
 // API functions
-export const createCharacter = async (characterData: CharacterCreateRequest): Promise<Character> => {
-  try {
-    const response = await apiClient.post('/game/character', characterData);
-    return response.data;
-  } catch (error) {
-    console.error('Error creating character:', error);
-    throw error;
-  }
+export const createCharacter = async (
+	characterData: CharacterCreateRequest,
+): Promise<Character> => {
+	try {
+		const response = await apiClient.post("/game/character", characterData);
+		return response.data;
+	} catch (error) {
+		console.error("Error creating character:", error);
+		throw error;
+	}
 };
 
 export const getCharacter = async (characterId: string): Promise<Character> => {
-  try {
-    const response = await apiClient.get(`/game/character/${characterId}`);
-    return response.data;
-  } catch (error) {
-    console.error(`Error fetching character ${characterId}:`, error);
-    throw error;
-  }
+	try {
+		const response = await apiClient.get(`/game/character/${characterId}`);
+		return response.data;
+	} catch (error) {
+		console.error(`Error fetching character ${characterId}:`, error);
+		throw error;
+	}
 };
 
-export const sendPlayerInput = async (input: PlayerInputRequest): Promise<GameResponse> => {
-  try {
-    const response = await apiClient.post('/game/input', input);
-    return response.data;
-  } catch (error) {
-    console.error('Error sending player input:', error);
-    throw error;
-  }
+export const sendPlayerInput = async (
+	input: PlayerInputRequest,
+): Promise<GameResponse> => {
+	try {
+		const response = await apiClient.post("/game/input", input);
+		return response.data;
+	} catch (error) {
+		console.error("Error sending player input:", error);
+		throw error;
+	}
 };
 
-export const createCampaign = async (campaignData: CampaignCreateRequest): Promise<Campaign> => {
-  try {
-    const response = await apiClient.post('/game/campaign', campaignData);
-    return response.data;
-  } catch (error) {
-    console.error('Error creating campaign:', error);
-    throw error;
-  }
+export const createCampaign = async (
+	campaignData: CampaignCreateRequest,
+): Promise<Campaign> => {
+	try {
+		const response = await apiClient.post("/game/campaign", campaignData);
+		return response.data;
+	} catch (error) {
+		console.error("Error creating campaign:", error);
+		throw error;
+	}
 };
 
-export const generateImage = async (imageRequest: ImageGenerateRequest): Promise<any> => {
-  try {
-    const response = await apiClient.post('/game/generate-image', imageRequest);
-    return response.data;
-  } catch (error) {
-    console.error('Error generating image:', error);
-    throw error;
-  }
+export const generateImage = async (
+	imageRequest: ImageGenerateRequest,
+): Promise<unknown> => {
+	try {
+		const response = await apiClient.post("/game/generate-image", imageRequest);
+		return response.data;
+	} catch (error) {
+		console.error("Error generating image:", error);
+		throw error;
+	}
 };
 
-export const generateBattleMap = async (mapRequest: BattleMapRequest): Promise<any> => {
-  try {
-    const response = await apiClient.post('/game/battle-map', mapRequest);
-    return response.data;
-  } catch (error) {
-    console.error('Error generating battle map:', error);
-    throw error;
-  }
+export const generateBattleMap = async (
+	mapRequest: BattleMapRequest,
+): Promise<unknown> => {
+	try {
+		const response = await apiClient.post("/game/battle-map", mapRequest);
+		return response.data;
+	} catch (error) {
+		console.error("Error generating battle map:", error);
+		throw error;
+	}
 };


### PR DESCRIPTION
## Summary
- run Biome and fix lint issues
- update component code and tests to satisfy linting
- ensure buttons have explicit type
- remove `any` usages in API types and tests
- fix ChatBox scrolling hook and keys

## Testing
- `npx biome check .`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68492263b74c833298c91925a19a8579