### PR TITLE
Propagate configured Azure secrets to Copilot agent environment

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -28,15 +28,26 @@ The workflow automatically handles:
 1. Python and Node.js environment setup
 2. Dependency installation with caching (Python via UV, Node.js via npm)
 3. Repository checkout for dependency installation
-4. Azure secrets exposure for local development and testing
+4. Azure secrets exposure for local development and testing (only the secrets configured in the repository are surfaced)
 
 #### Available Azure Environment Variables
 
-The following Azure secrets are automatically available as environment variables during Copilot agent sessions for local testing and Playwright E2E tests:
+The GitHub Actions setup job runs immediately before the Copilot coding agent session starts. Because the coding agent reuses the same runner that executed the workflow, any variables written to the runner environment via `$GITHUB_ENV` become available to the agent automatically.
 
-- `AZURE_CLIENT_ID` - Application (client) ID from service principal
+During the "Propagate configured Azure secrets" step, the workflow writes each configured secret from the list below into the environment. Secrets that are not configured in the repository are skipped, so you can maintain the minimal three-secret configuration without errors while still allowing additional deployments to be surfaced in the future.
+
+Currently configured secrets:
+
 - `AZURE_OPENAI_API_KEY` - Azure AI Foundry API key for OpenAI services
 - `AZURE_OPENAI_ENDPOINT` - Azure OpenAI endpoint URL (e.g., `https://your-project.openai.azure.com/`)
+- `AZURE_OPENAI_CHAT_DEPLOYMENT` - Chat model deployment name (e.g., `gpt-4o-mini`)
+
+Optionally supported secrets (add these in repository settings to expose them to the agent):
+
+- `AZURE_CLIENT_ID` - Application (client) ID from service principal
+- `AZURE_OPENAI_API_VERSION` - Azure OpenAI API version for deployed models
+- `AZURE_OPENAI_EMBEDDING_DEPLOYMENT` - Embedding model deployment name (e.g., `text-embedding-3-large`)
+- `AZURE_OPENAI_DALLE_DEPLOYMENT` - Image generation deployment name (e.g., `dall-e-3`)
 - `AZURE_SUBSCRIPTION_ID` - Azure subscription ID
 - `AZURE_TENANT_ID` - Directory (tenant) ID
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -23,16 +23,50 @@ jobs:
     permissions:
       contents: read
 
-    # Environment variables available to the Copilot agent during development
-    # These secrets are automatically masked in GitHub logs
-    env:
-      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-      AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
-      AZURE_OPENAI_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
-      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-
     steps:
+      - name: Propagate configured Azure secrets to Copilot agent
+        env:
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
+          AZURE_OPENAI_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
+          AZURE_OPENAI_API_VERSION: ${{ secrets.AZURE_OPENAI_API_VERSION }}
+          AZURE_OPENAI_CHAT_DEPLOYMENT: ${{ secrets.AZURE_OPENAI_CHAT_DEPLOYMENT }}
+          AZURE_OPENAI_EMBEDDING_DEPLOYMENT: ${{ secrets.AZURE_OPENAI_EMBEDDING_DEPLOYMENT }}
+          AZURE_OPENAI_DALLE_DEPLOYMENT: ${{ secrets.AZURE_OPENAI_DALLE_DEPLOYMENT }}
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+        run: |
+          set -euo pipefail
+
+          : "${GITHUB_STEP_SUMMARY:=/tmp/copilot-step-summary.md}"
+          touch "$GITHUB_STEP_SUMMARY"
+
+          echo "The following Azure secrets will be available to the Copilot coding agent:" >> "$GITHUB_STEP_SUMMARY"
+
+          for var in \
+            AZURE_CLIENT_ID \
+            AZURE_OPENAI_API_KEY \
+            AZURE_OPENAI_ENDPOINT \
+            AZURE_OPENAI_API_VERSION \
+            AZURE_OPENAI_CHAT_DEPLOYMENT \
+            AZURE_OPENAI_EMBEDDING_DEPLOYMENT \
+            AZURE_OPENAI_DALLE_DEPLOYMENT \
+            AZURE_SUBSCRIPTION_ID \
+            AZURE_TENANT_ID
+          do
+            value="${!var:-}"
+
+            if [ -n "$value" ]; then
+              echo "${var}=$value" >> "$GITHUB_ENV"
+              printf -- "- %s\n" "$var" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          done
+
+          # Ensure the summary reflects when no optional secrets are configured
+          if ! grep -q '^-' "$GITHUB_STEP_SUMMARY"; then
+            echo "- (no Azure secrets configured in repository settings)" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
       # Checkout code to install project dependencies.
       # If this step is omitted, Copilot will clone the repository automatically after setup.
       - name: Checkout code


### PR DESCRIPTION
## Summary
- expose Copilot coding agent secrets via a dedicated setup step that only persists repository-configured Azure values to the runner environment
- document how the Copilot runner shares its environment with the coding agent and distinguish between currently configured Azure secrets and optional additions

## Testing
- make format
- make lint *(fails: existing repository lint errors in tests and scripts)*
- make test *(fails: existing backend failures that require full Azure/semantic-kernel configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68eae2dc1a548332807aad15d2892dc9