### PR TITLE
Fix failing frontend tests

### DIFF
--- a/frontend/src/api-client/__tests__/websocketClient.test.ts
+++ b/frontend/src/api-client/__tests__/websocketClient.test.ts
@@ -118,7 +118,7 @@ describe("WebSocket Client SDK", () => {
       await new Promise((resolve) => setTimeout(resolve, 10));
 
       const socket = connection.getSocket();
-      expect(socket?.url).toBe("ws://localhost:8000/api/ws/test-campaign-id");
+      expect(socket?.url).toBe("ws://localhost:8000/ws/test-campaign-id");
     });
 
     it("should handle disconnect", async () => {
@@ -164,7 +164,7 @@ describe("WebSocket Client SDK", () => {
 
       const socket = connection.getSocket();
       expect(socket?.url).toBe(
-        "ws://localhost:8000/api/ws/chat/test-campaign-id"
+        "ws://localhost:8000/ws/chat/test-campaign-id"
       );
     });
   });
@@ -194,7 +194,7 @@ describe("WebSocket Client SDK", () => {
       await new Promise((resolve) => setTimeout(resolve, 10));
 
       const socket = connection.getSocket();
-      expect(socket?.url).toBe("ws://localhost:8000/api/ws/global");
+      expect(socket?.url).toBe("ws://localhost:8000/ws/global");
     });
   });
 

--- a/frontend/src/services/api-client.test.ts
+++ b/frontend/src/services/api-client.test.ts
@@ -125,31 +125,31 @@ describe("OpenAPI Generated Client Integration", () => {
 
   describe("API Methods Availability", () => {
     it("should have character creation method", () => {
-      expect(gameApiClient.createCharacterApiGameCharacterPost).toBeDefined();
-      expect(typeof gameApiClient.createCharacterApiGameCharacterPost).toBe(
+      expect(gameApiClient.createCharacterGameCharacterPost).toBeDefined();
+      expect(typeof gameApiClient.createCharacterGameCharacterPost).toBe(
         "function"
       );
     });
 
     it("should have character retrieval method", () => {
       expect(
-        gameApiClient.getCharacterApiGameCharacterCharacterIdGet
+        gameApiClient.getCharacterGameCharacterCharacterIdGet
       ).toBeDefined();
       expect(
-        typeof gameApiClient.getCharacterApiGameCharacterCharacterIdGet
+        typeof gameApiClient.getCharacterGameCharacterCharacterIdGet
       ).toBe("function");
     });
 
     it("should have campaign creation method", () => {
-      expect(gameApiClient.createCampaignApiGameCampaignPost).toBeDefined();
-      expect(typeof gameApiClient.createCampaignApiGameCampaignPost).toBe(
+      expect(gameApiClient.createCampaignGameCampaignPost).toBeDefined();
+      expect(typeof gameApiClient.createCampaignGameCampaignPost).toBe(
         "function"
       );
     });
 
     it("should have player input method", () => {
-      expect(gameApiClient.processPlayerInputApiGameInputPost).toBeDefined();
-      expect(typeof gameApiClient.processPlayerInputApiGameInputPost).toBe(
+      expect(gameApiClient.processPlayerInputGameInputPost).toBeDefined();
+      expect(typeof gameApiClient.processPlayerInputGameInputPost).toBe(
         "function"
       );
     });
@@ -232,11 +232,11 @@ describe("OpenAPI Generated Client Integration", () => {
       const mockError = new Error("Network error");
       vi.spyOn(
         gameApiClient,
-        "createCharacterApiGameCharacterPost"
+        "createCharacterGameCharacterPost"
       ).mockRejectedValue(mockError);
 
       try {
-        await gameApiClient.createCharacterApiGameCharacterPost({
+        await gameApiClient.createCharacterGameCharacterPost({
           name: "Test",
           race: Race.Human,
           characterClass: CharacterClass.Fighter,


### PR DESCRIPTION
- Update WebSocket test URLs to match actual backend routes (/ws/... instead of /api/ws/...)
- Fix API method name expectations in api-client.test.ts to match generated OpenAPI client
- Backend mounts WebSocket routes without /api prefix, tests now reflect actual implementation
- All 139 tests now passing (15 test files)