### PR TITLE
Fix invalid app directory path in deployment

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,6 +3,9 @@ import { defineConfig } from "vite";
 
 export default defineConfig({
   plugins: [react()],
+  build: {
+    outDir: "build",
+  },
   test: {
     globals: true,
     environment: "jsdom",
@@ -28,7 +31,7 @@ export default defineConfig({
     isolate: true,
     exclude: [
       "**/node_modules/**",
-      "**/dist/**",
+      "**/build/**",
       "**/e2e/**",
       "**/.{git,cache,output,temp}/**",
       "**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build}.config.*",


### PR DESCRIPTION
The deployment workflow expects the frontend build output at 'frontend/build', but Vite was outputting to 'frontend/dist' by default. This mismatch caused deployment failures with the error:
"App Directory Location: 'frontend/build' is invalid. Could not detect this directory."

Changes:
- Configure Vite build.outDir to 'build' instead of default 'dist'
- Update test exclusion path from 'dist' to 'build' for consistency

This ensures the build output location matches the deployment configuration in .github/workflows/deploy-environment.yml (line 33).