### PR TITLE
Generate API client for frontend tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -59,11 +59,6 @@ jobs:
         cd frontend
         npx playwright install chromium
 
-    - name: Build frontend for E2E tests
-      run: |
-        cd frontend
-        npm run build
-
     - name: Setup Python (for backend mock server)
       uses: actions/setup-python@v4
       with:
@@ -83,6 +78,16 @@ jobs:
         cd backend
         uv run python -m uvicorn app.main:app --host 0.0.0.0 --port 8000 &
         sleep 10  # Give server time to start
+
+    - name: Generate API client
+      run: |
+        cd frontend
+        npm run generate:api
+
+    - name: Build frontend for E2E tests
+      run: |
+        cd frontend
+        npm run build
       
     - name: Start frontend dev server
       run: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -44,10 +44,35 @@ jobs:
         cache: 'npm'
         cache-dependency-path: frontend/package-lock.json
 
+    - name: Setup Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.12'
+
+    - name: Install UV
+      run: curl -LsSf https://astral.sh/uv/install.sh | sh
+
+    - name: Install backend dependencies
+      run: |
+        export PATH="$HOME/.local/bin:$PATH"
+        uv sync
+
+    - name: Start backend server
+      run: |
+        export PATH="$HOME/.local/bin:$PATH"
+        cd backend
+        uv run python -m uvicorn app.main:app --host 0.0.0.0 --port 8000 &
+        sleep 10
+
     - name: Install frontend dependencies
       run: |
         cd frontend
         npm ci --legacy-peer-deps
+
+    - name: Generate API client
+      run: |
+        cd frontend
+        npm run generate:api
 
     - name: Run frontend unit tests (fast)
       run: |


### PR DESCRIPTION
The frontend unit tests and e2e tests workflows were failing because the API client (src/api-client/) was missing. This directory is generated from the backend's OpenAPI schema and is not committed to the repository.

Changes:
- unit-tests.yml: Added backend setup and API client generation before running frontend tests
- e2e-tests.yml: Added API client generation step after starting backend and before building frontend

Both workflows now:
1. Start the backend server (required for OpenAPI schema)
2. Generate the TypeScript API client via npm run generate:api
3. Then proceed with tests/build

This follows the pattern used in the deploy workflow and ensures the frontend code can import from ../api-client as expected.