### PR TITLE
feat: add NPC dialogue system with conversation memory

### DIFF
--- a/backend/app/api/routes/npc_routes.py
+++ b/backend/app/api/routes/npc_routes.py
@@ -24,8 +24,10 @@ from app.models.game_models import (
     NPCProfileWithRelationship,
     NPCRelationship,
     NPCStatsResponse,
+    RecordConversationRequest,
     UpdateDispositionRequest,
 )
+from app.services.npc_dialogue_service import npc_dialogue_service
 
 logger = logging.getLogger(__name__)
 
@@ -295,6 +297,7 @@ async def list_npc_profiles(
             location=row.location or "",
             is_alive=row.is_alive,
             conversation_notes=row.conversation_notes or [],
+            conversation_history=row.conversation_history or [],
         )
         for row in rows
     ]
@@ -319,6 +322,7 @@ async def create_npc_profile(
         location=request.location,
         is_alive=True,
         conversation_notes=[],
+        conversation_history=[],
     )
     db.add(row)
     db.commit()
@@ -332,6 +336,7 @@ async def create_npc_profile(
         location=row.location or "",
         is_alive=row.is_alive,
         conversation_notes=row.conversation_notes or [],
+        conversation_history=row.conversation_history or [],
     )
 
 
@@ -361,6 +366,7 @@ async def get_npc_profile(
         location=row.location or "",
         is_alive=row.is_alive,
         conversation_notes=row.conversation_notes or [],
+        conversation_history=row.conversation_history or [],
     )
     rel_row = (
         db.query(NPCRelationshipDB)
@@ -446,3 +452,58 @@ async def update_npc_disposition(
         key_events=rel_row.key_events or [],
         last_interaction=rel_row.last_interaction or "",
     )
+
+
+# ---------------------------------------------------------------------------
+# NPC Dialogue endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("/npcs/{campaign_id}/{npc_id}/dialogue-context")
+async def get_npc_dialogue_context(
+    campaign_id: str,
+    npc_id: str,
+    db: DbDep,
+) -> dict:
+    """Get NPC context for dialogue generation."""
+    ctx = npc_dialogue_service.get_npc_context(npc_id, campaign_id, db)
+    if not ctx:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"NPC {npc_id} not found in campaign {campaign_id}",
+        )
+    return ctx
+
+
+@router.post(
+    "/npcs/{campaign_id}/{npc_id}/conversation",
+    status_code=status.HTTP_201_CREATED,
+)
+async def record_npc_conversation(
+    campaign_id: str,
+    npc_id: str,
+    request: RecordConversationRequest,
+    db: DbDep,
+) -> dict:
+    """Record a conversation interaction with an NPC."""
+    # Verify NPC exists
+    npc_row = (
+        db.query(NPCProfileDB)
+        .filter(NPCProfileDB.id == npc_id, NPCProfileDB.campaign_id == campaign_id)
+        .first()
+    )
+    if npc_row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"NPC {npc_id} not found in campaign {campaign_id}",
+        )
+
+    npc_dialogue_service.record_conversation(
+        npc_id=npc_id,
+        campaign_id=campaign_id,
+        summary=request.summary,
+        disposition_change=request.disposition_change,
+        topics=request.topics,
+        db=db,
+    )
+    return {"status": "recorded", "npc_id": npc_id, "campaign_id": campaign_id}

--- a/backend/app/models/db_models.py
+++ b/backend/app/models/db_models.py
@@ -149,6 +149,7 @@ class NPCProfileDB(Base):
     location = Column(String, nullable=True)
     is_alive = Column(Boolean, nullable=False, default=True)
     conversation_notes = Column(JSON, nullable=False, default=list)
+    conversation_history = Column(JSON, nullable=False, default=list)
     created_at = Column(DateTime, nullable=False, default=_utcnow)
     updated_at = Column(DateTime, nullable=False, default=_utcnow, onupdate=_utcnow)
 

--- a/backend/app/models/game_models.py
+++ b/backend/app/models/game_models.py
@@ -722,6 +722,15 @@ class SaveSlotListResponse(BaseModel):
 # NPC Profile models for game-engine disposition tracking
 
 
+class NPCConversationEntry(BaseModel):
+    """A single recorded conversation with an NPC."""
+
+    timestamp: str
+    summary: str
+    disposition_change: int = 0
+    topics: list[str] = Field(default_factory=list)
+
+
 class NPCProfile(BaseModel):
     id: str = Field(default_factory=lambda: str(uuid.uuid4()))
     name: str
@@ -731,6 +740,7 @@ class NPCProfile(BaseModel):
     location: str = ""
     is_alive: bool = True
     conversation_notes: list[str] = Field(default_factory=list)
+    conversation_history: list[NPCConversationEntry] = Field(default_factory=list)
 
 
 class NPCRelationship(BaseModel):
@@ -753,6 +763,14 @@ class CreateNPCProfileRequest(BaseModel):
 class UpdateDispositionRequest(BaseModel):
     disposition_score: int
     event_note: str | None = Field(default=None, max_length=500)
+
+
+class RecordConversationRequest(BaseModel):
+    """Request body for recording an NPC conversation."""
+
+    summary: str = Field(max_length=2000)
+    disposition_change: int = 0
+    topics: list[str] = Field(default_factory=list)
 
 
 class NPCProfileWithRelationship(BaseModel):

--- a/backend/app/services/npc_dialogue_service.py
+++ b/backend/app/services/npc_dialogue_service.py
@@ -1,0 +1,231 @@
+"""Service for NPC dialogue context and conversation memory."""
+
+import logging
+from datetime import UTC, datetime
+
+from sqlalchemy.orm import Session
+
+from app.models.db_models import NPCProfileDB, NPCRelationshipDB
+from app.models.game_models import NPCConversationEntry
+
+logger = logging.getLogger(__name__)
+
+# Disposition score bounds
+_MIN_DISPOSITION = -100
+_MAX_DISPOSITION = 100
+
+# Number of recent conversations to include in dialogue context
+_RECENT_CONVERSATION_LIMIT = 10
+
+
+def _disposition_tone(score: int) -> str:
+    """Map a disposition score to a descriptive tone for dialogue generation."""
+    if score >= 50:
+        return "warm and enthusiastic, treating the party as trusted allies"
+    if score >= 20:
+        return "friendly and helpful, willing to share information"
+    if score >= -19:
+        return "polite but guarded, sticking to business"
+    if score >= -49:
+        return "cold and suspicious, reluctant to cooperate"
+    return "openly hostile, dismissive and threatening"
+
+
+class NPCDialogueService:
+    """Manages NPC dialogue context and conversation memory."""
+
+    def get_npc_context(
+        self, npc_id: str, campaign_id: str, db: Session
+    ) -> dict:
+        """Get full NPC context for the narrator agent.
+
+        Returns personality, relationship data, and recent conversations
+        so the DM agent can voice this NPC accurately.
+
+        Args:
+            npc_id: The NPC profile ID.
+            campaign_id: The campaign ID.
+            db: SQLAlchemy session.
+
+        Returns:
+            Dict with profile, relationship, and recent_conversations keys.
+        """
+        profile_row = (
+            db.query(NPCProfileDB)
+            .filter(
+                NPCProfileDB.id == npc_id,
+                NPCProfileDB.campaign_id == campaign_id,
+            )
+            .first()
+        )
+        if profile_row is None:
+            return {}
+
+        rel_row = (
+            db.query(NPCRelationshipDB)
+            .filter(
+                NPCRelationshipDB.npc_id == npc_id,
+                NPCRelationshipDB.campaign_id == campaign_id,
+            )
+            .first()
+        )
+
+        history: list[dict] = list(profile_row.conversation_history or [])
+        recent = history[-_RECENT_CONVERSATION_LIMIT:]
+
+        disposition_score = rel_row.disposition_score if rel_row else 0
+
+        return {
+            "name": profile_row.name,
+            "description": profile_row.description or "",
+            "personality_traits": list(profile_row.personality_traits or []),
+            "disposition": profile_row.disposition,
+            "disposition_score": disposition_score,
+            "disposition_tone": _disposition_tone(disposition_score),
+            "location": profile_row.location or "",
+            "is_alive": profile_row.is_alive,
+            "conversation_notes": list(profile_row.conversation_notes or []),
+            "recent_conversations": recent,
+            "interactions_count": rel_row.interactions_count if rel_row else 0,
+            "key_events": list(rel_row.key_events or []) if rel_row else [],
+        }
+
+    def record_conversation(
+        self,
+        npc_id: str,
+        campaign_id: str,
+        summary: str,
+        disposition_change: int,
+        topics: list[str],
+        db: Session,
+    ) -> None:
+        """Record a conversation interaction with an NPC.
+
+        Appends the conversation to the NPC's history, updates
+        conversation_notes with the summary, and adjusts the
+        relationship disposition score.
+
+        Args:
+            npc_id: The NPC profile ID.
+            campaign_id: The campaign ID.
+            summary: A short summary of the conversation.
+            disposition_change: How much the disposition score should shift.
+            topics: Key topics discussed.
+            db: SQLAlchemy session.
+        """
+        profile_row = (
+            db.query(NPCProfileDB)
+            .filter(
+                NPCProfileDB.id == npc_id,
+                NPCProfileDB.campaign_id == campaign_id,
+            )
+            .first()
+        )
+        if profile_row is None:
+            return
+
+        entry = NPCConversationEntry(
+            timestamp=datetime.now(UTC).isoformat(),
+            summary=summary,
+            disposition_change=disposition_change,
+            topics=topics,
+        )
+
+        # Append to conversation history
+        history: list[dict] = list(profile_row.conversation_history or [])
+        history.append(entry.model_dump())
+        profile_row.conversation_history = history
+
+        # Append summary to conversation_notes
+        notes: list[str] = list(profile_row.conversation_notes or [])
+        notes.append(summary)
+        profile_row.conversation_notes = notes
+
+        # Update or create relationship
+        now_str = datetime.now(UTC).isoformat()
+        rel_row = (
+            db.query(NPCRelationshipDB)
+            .filter(
+                NPCRelationshipDB.npc_id == npc_id,
+                NPCRelationshipDB.campaign_id == campaign_id,
+            )
+            .first()
+        )
+        if rel_row is None:
+            import uuid
+
+            rel_row = NPCRelationshipDB(
+                id=str(uuid.uuid4()),
+                npc_id=npc_id,
+                campaign_id=campaign_id,
+                disposition_score=max(
+                    _MIN_DISPOSITION,
+                    min(_MAX_DISPOSITION, disposition_change),
+                ),
+                interactions_count=1,
+                key_events=[summary] if summary else [],
+                last_interaction=now_str,
+            )
+            db.add(rel_row)
+        else:
+            new_score = rel_row.disposition_score + disposition_change
+            rel_row.disposition_score = max(
+                _MIN_DISPOSITION, min(_MAX_DISPOSITION, new_score)
+            )
+            rel_row.interactions_count = (rel_row.interactions_count or 0) + 1
+            rel_row.last_interaction = now_str
+            existing_events: list[str] = list(rel_row.key_events or [])
+            if summary:
+                existing_events.append(summary)
+            rel_row.key_events = existing_events
+
+        db.commit()
+
+    def get_dialogue_prompt(
+        self, npc_id: str, campaign_id: str, db: Session
+    ) -> str:
+        """Generate a system prompt snippet for the DM agent to voice this NPC.
+
+        Args:
+            npc_id: The NPC profile ID.
+            campaign_id: The campaign ID.
+            db: SQLAlchemy session.
+
+        Returns:
+            A string prompt snippet describing how to portray this NPC.
+        """
+        ctx = self.get_npc_context(npc_id, campaign_id, db)
+        if not ctx:
+            return ""
+
+        parts: list[str] = []
+        name = ctx.get("name", "Unknown NPC")
+        parts.append(f"You are voicing {name}.")
+
+        description = ctx.get("description")
+        if description:
+            parts.append(f"Description: {description}")
+
+        traits = ctx.get("personality_traits", [])
+        if traits:
+            parts.append(f"Personality traits: {', '.join(traits)}.")
+
+        tone = ctx.get("disposition_tone", "")
+        if tone:
+            parts.append(f"Current demeanour: {tone}.")
+
+        recent = ctx.get("recent_conversations", [])
+        if recent:
+            last_topics: list[str] = []
+            for conv in recent[-3:]:
+                last_topics.extend(conv.get("topics", []))
+            if last_topics:
+                unique_topics = list(dict.fromkeys(last_topics))
+                parts.append(
+                    f"Recent conversation topics: {', '.join(unique_topics)}."
+                )
+
+        return " ".join(parts)
+
+
+npc_dialogue_service = NPCDialogueService()

--- a/backend/tests/test_npc_dialogue.py
+++ b/backend/tests/test_npc_dialogue.py
@@ -1,0 +1,343 @@
+"""Tests for the NPC dialogue system with conversation memory."""
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.database import Base, get_session
+from app.main import app
+from app.services.npc_dialogue_service import NPCDialogueService
+
+
+def _make_test_db():
+    """Create an isolated in-memory SQLite database for testing."""
+    import app.models.db_models  # noqa: F401
+
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    return sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+@pytest.fixture
+def test_session_factory():
+    """Provide a session factory bound to an in-memory database."""
+    return _make_test_db()
+
+
+@pytest.fixture
+def db(test_session_factory) -> Session:
+    """Provide a single database session for service-level tests."""
+    session = test_session_factory()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture
+def client(test_session_factory):
+    """Test client backed by an isolated in-memory database."""
+
+    def override_get_session():
+        session = test_session_factory()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    app.dependency_overrides[get_session] = override_get_session
+    yield TestClient(app)
+    app.dependency_overrides.pop(get_session, None)
+
+
+@pytest.fixture
+def campaign_id() -> str:
+    return "test_campaign_dialogue"
+
+
+@pytest.fixture
+def service() -> NPCDialogueService:
+    return NPCDialogueService()
+
+
+def _create_npc_via_api(client: TestClient, campaign_id: str, **kwargs) -> str:
+    """Create an NPC profile via the API and return its ID."""
+    payload = {"name": kwargs.pop("name", "Test NPC"), **kwargs}
+    resp = client.post(f"/game/npcs/{campaign_id}", json=payload)
+    assert resp.status_code == 201
+    return resp.json()["id"]
+
+
+# ---------------------------------------------------------------------------
+# Endpoint tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetDialogueContext:
+    """Tests for GET /game/npcs/{campaign_id}/{npc_id}/dialogue-context."""
+
+    def test_returns_personality_and_relationship(self, client, campaign_id) -> None:
+        """Dialogue context includes personality traits and relationship data."""
+        npc_id = _create_npc_via_api(
+            client,
+            campaign_id,
+            name="Elara",
+            personality_traits=["wise", "patient"],
+            description="An elderly sage",
+        )
+        # Set a disposition so relationship exists
+        client.patch(
+            f"/game/npcs/{campaign_id}/{npc_id}/disposition",
+            json={"disposition_score": 40, "event_note": "Helped find her cat"},
+        )
+
+        resp = client.get(f"/game/npcs/{campaign_id}/{npc_id}/dialogue-context")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["name"] == "Elara"
+        assert "wise" in data["personality_traits"]
+        assert "patient" in data["personality_traits"]
+        assert data["description"] == "An elderly sage"
+        assert data["disposition_score"] == 40
+        assert data["interactions_count"] == 1
+        assert "Helped find her cat" in data["key_events"]
+
+    def test_returns_recent_conversations(self, client, campaign_id) -> None:
+        """Dialogue context includes recently recorded conversations."""
+        npc_id = _create_npc_via_api(client, campaign_id, name="Barkeep")
+        # Record a conversation
+        client.post(
+            f"/game/npcs/{campaign_id}/{npc_id}/conversation",
+            json={
+                "summary": "Asked about rumours in town",
+                "disposition_change": 5,
+                "topics": ["rumours", "town"],
+            },
+        )
+
+        resp = client.get(f"/game/npcs/{campaign_id}/{npc_id}/dialogue-context")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["recent_conversations"]) == 1
+        assert data["recent_conversations"][0]["summary"] == "Asked about rumours in town"
+        assert "rumours" in data["recent_conversations"][0]["topics"]
+
+    def test_empty_history_returns_valid_context(self, client, campaign_id) -> None:
+        """NPC with no conversation history still returns a valid context dict."""
+        npc_id = _create_npc_via_api(client, campaign_id, name="Silent Guard")
+        resp = client.get(f"/game/npcs/{campaign_id}/{npc_id}/dialogue-context")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["name"] == "Silent Guard"
+        assert data["recent_conversations"] == []
+        assert data["conversation_notes"] == []
+        assert data["disposition_score"] == 0
+        assert data["interactions_count"] == 0
+        assert "disposition_tone" in data
+
+    def test_unknown_npc_returns_404(self, client, campaign_id) -> None:
+        """Requesting dialogue context for a non-existent NPC returns 404."""
+        resp = client.get(f"/game/npcs/{campaign_id}/nonexistent/dialogue-context")
+        assert resp.status_code == 404
+
+
+class TestRecordConversation:
+    """Tests for POST /game/npcs/{campaign_id}/{npc_id}/conversation."""
+
+    def test_record_conversation_returns_201(self, client, campaign_id) -> None:
+        """Recording a conversation returns HTTP 201."""
+        npc_id = _create_npc_via_api(client, campaign_id, name="Merchant")
+        resp = client.post(
+            f"/game/npcs/{campaign_id}/{npc_id}/conversation",
+            json={"summary": "Bought a healing potion"},
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["status"] == "recorded"
+        assert data["npc_id"] == npc_id
+
+    def test_record_conversation_updates_notes_and_disposition(
+        self, client, campaign_id
+    ) -> None:
+        """Recording a conversation updates conversation_notes and disposition score."""
+        npc_id = _create_npc_via_api(client, campaign_id, name="Blacksmith")
+
+        client.post(
+            f"/game/npcs/{campaign_id}/{npc_id}/conversation",
+            json={
+                "summary": "Commissioned a new sword",
+                "disposition_change": 10,
+                "topics": ["weapons", "crafting"],
+            },
+        )
+
+        # Verify via the profile endpoint
+        profile_resp = client.get(f"/game/npcs/{campaign_id}/{npc_id}")
+        assert profile_resp.status_code == 200
+        profile_data = profile_resp.json()
+        assert "Commissioned a new sword" in profile_data["profile"]["conversation_notes"]
+
+        # Relationship should have been created
+        rel = profile_data["relationship"]
+        assert rel is not None
+        assert rel["disposition_score"] == 10
+        assert rel["interactions_count"] == 1
+
+    def test_multiple_conversations_accumulate(self, client, campaign_id) -> None:
+        """Multiple recorded conversations stack disposition changes."""
+        npc_id = _create_npc_via_api(client, campaign_id, name="Innkeeper")
+
+        client.post(
+            f"/game/npcs/{campaign_id}/{npc_id}/conversation",
+            json={"summary": "Rented a room", "disposition_change": 5},
+        )
+        client.post(
+            f"/game/npcs/{campaign_id}/{npc_id}/conversation",
+            json={"summary": "Complimented the stew", "disposition_change": 10},
+        )
+
+        profile_resp = client.get(f"/game/npcs/{campaign_id}/{npc_id}")
+        rel = profile_resp.json()["relationship"]
+        assert rel["disposition_score"] == 15
+        assert rel["interactions_count"] == 2
+
+        notes = profile_resp.json()["profile"]["conversation_notes"]
+        assert "Rented a room" in notes
+        assert "Complimented the stew" in notes
+
+    def test_record_conversation_unknown_npc_returns_404(
+        self, client, campaign_id
+    ) -> None:
+        """Recording a conversation for a non-existent NPC returns 404."""
+        resp = client.post(
+            f"/game/npcs/{campaign_id}/nonexistent/conversation",
+            json={"summary": "Hello"},
+        )
+        assert resp.status_code == 404
+
+
+class TestDialoguePrompt:
+    """Tests for NPCDialogueService.get_dialogue_prompt (service-level)."""
+
+    def _create_npc_in_db(self, db: Session, campaign_id: str, **kwargs) -> str:
+        """Insert an NPC profile directly into the database."""
+        import uuid
+
+        from app.models.db_models import NPCProfileDB
+
+        npc_id = str(uuid.uuid4())
+        row = NPCProfileDB(
+            id=npc_id,
+            campaign_id=campaign_id,
+            name=kwargs.get("name", "Test NPC"),
+            description=kwargs.get("description", ""),
+            personality_traits=kwargs.get("personality_traits", []),
+            disposition=kwargs.get("disposition", "neutral"),
+            location=kwargs.get("location", ""),
+            is_alive=True,
+            conversation_notes=[],
+            conversation_history=[],
+        )
+        db.add(row)
+        db.commit()
+        return npc_id
+
+    def test_prompt_includes_personality(self, service, db, campaign_id) -> None:
+        """Dialogue prompt mentions personality traits."""
+        npc_id = self._create_npc_in_db(
+            db,
+            campaign_id,
+            name="Grumpy Dwarf",
+            personality_traits=["grumpy", "loyal"],
+        )
+        prompt = service.get_dialogue_prompt(npc_id, campaign_id, db)
+        assert "Grumpy Dwarf" in prompt
+        assert "grumpy" in prompt
+        assert "loyal" in prompt
+
+    def test_prompt_includes_description(self, service, db, campaign_id) -> None:
+        """Dialogue prompt includes NPC description."""
+        npc_id = self._create_npc_in_db(
+            db,
+            campaign_id,
+            name="The Oracle",
+            description="A blind seer who speaks in riddles",
+        )
+        prompt = service.get_dialogue_prompt(npc_id, campaign_id, db)
+        assert "A blind seer who speaks in riddles" in prompt
+
+    def test_disposition_affects_tone(self, service, db, campaign_id) -> None:
+        """Different disposition scores produce different tone descriptions."""
+        import uuid
+
+        from app.models.db_models import NPCRelationshipDB
+
+        npc_id = self._create_npc_in_db(db, campaign_id, name="Guard Captain")
+
+        # Create a friendly relationship
+        rel = NPCRelationshipDB(
+            id=str(uuid.uuid4()),
+            npc_id=npc_id,
+            campaign_id=campaign_id,
+            disposition_score=60,
+            interactions_count=5,
+            key_events=[],
+            last_interaction="",
+        )
+        db.add(rel)
+        db.commit()
+
+        prompt = service.get_dialogue_prompt(npc_id, campaign_id, db)
+        assert "warm" in prompt or "trusted" in prompt or "allies" in prompt
+
+    def test_hostile_disposition_tone(self, service, db, campaign_id) -> None:
+        """Hostile disposition produces appropriately negative tone."""
+        import uuid
+
+        from app.models.db_models import NPCRelationshipDB
+
+        npc_id = self._create_npc_in_db(db, campaign_id, name="Bandit Leader")
+
+        rel = NPCRelationshipDB(
+            id=str(uuid.uuid4()),
+            npc_id=npc_id,
+            campaign_id=campaign_id,
+            disposition_score=-70,
+            interactions_count=2,
+            key_events=[],
+            last_interaction="",
+        )
+        db.add(rel)
+        db.commit()
+
+        prompt = service.get_dialogue_prompt(npc_id, campaign_id, db)
+        assert "hostile" in prompt or "threatening" in prompt or "dismissive" in prompt
+
+    def test_prompt_empty_for_unknown_npc(self, service, db, campaign_id) -> None:
+        """Dialogue prompt returns empty string for non-existent NPC."""
+        prompt = service.get_dialogue_prompt("nonexistent", campaign_id, db)
+        assert prompt == ""
+
+    def test_prompt_includes_recent_topics(self, service, db, campaign_id) -> None:
+        """Dialogue prompt references topics from recent conversations."""
+        npc_id = self._create_npc_in_db(db, campaign_id, name="Librarian")
+
+        # Record a conversation with topics
+        service.record_conversation(
+            npc_id=npc_id,
+            campaign_id=campaign_id,
+            summary="Discussed ancient tomes",
+            disposition_change=5,
+            topics=["ancient history", "forbidden knowledge"],
+            db=db,
+        )
+
+        prompt = service.get_dialogue_prompt(npc_id, campaign_id, db)
+        assert "ancient history" in prompt
+        assert "forbidden knowledge" in prompt


### PR DESCRIPTION
## Summary
- `NPCDialogueService` with context retrieval, conversation recording, and dialogue prompt generation
- Disposition-sensitive tone generation for DM agent NPC voicing
- Conversation history tracking with topic tagging
- 14 new tests + 16 existing NPC tests pass

Closes #507

## Test plan
- [x] Dialogue context returns personality + relationship + conversations
- [x] Conversation recording updates history and disposition
- [x] Dialogue prompt includes personality traits and disposition tone
- [x] Empty history returns valid context
- [x] 404 handling for missing NPCs

🤖 Generated with [Claude Code](https://claude.com/claude-code)