### PR TITLE
security: replace ACR admin credentials with managed identity (closes #558)

### DIFF
--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -258,22 +258,19 @@ jobs:
           IMAGE_SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
           DOCKER_IMAGE="${{ steps.infrastructure-deploy.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT }}/backend:sha-$IMAGE_SHORT_SHA"
 
-          # Retrieve ACR admin credentials for container app registry configuration
-          ACR_NAME="${{ steps.infrastructure-deploy.outputs.AZURE_CONTAINER_REGISTRY_NAME }}"
-          ACR_USERNAME=$(az acr credential show --name "$ACR_NAME" --query username --output tsv)
-          ACR_PASSWORD=$(az acr credential show --name "$ACR_NAME" --query passwords[0].value --output tsv)
-
           echo "Deploying image: $DOCKER_IMAGE"
 
-          # Create or update the container app using the pre-built image
+          # Use managed identity for registry auth (no admin credentials needed)
+          MANAGED_IDENTITY_ID="${{ steps.infrastructure-deploy.outputs.AZURE_MANAGED_IDENTITY_ID }}"
+
+          # Create or update the container app using managed identity for registry auth
           az containerapp up \
             --name "$CONTAINER_APP_NAME" \
             --resource-group "$RESOURCE_GROUP" \
             --environment "$CONTAINER_APP_ENVIRONMENT" \
             --image "$DOCKER_IMAGE" \
             --registry-server "${{ steps.infrastructure-deploy.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT }}" \
-            --registry-username "$ACR_USERNAME" \
-            --registry-password "$ACR_PASSWORD" \
+            --registry-identity "$MANAGED_IDENTITY_ID" \
             --target-port 8000 \
             --ingress external \
             --env-vars \

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -87,6 +87,28 @@ module containerRegistry 'modules/container-registry.bicep' = {
   }
 }
 
+// Create User-Assigned Managed Identity for container app
+module managedIdentity 'modules/managed-identity.bicep' = {
+  name: 'managed-identity'
+  scope: rg
+  params: {
+    name: '${environmentName}-id-${resourceToken}'
+    location: location
+    tags: tags
+  }
+}
+
+// Assign roles to managed identity (AcrPull + Storage Blob Data Contributor)
+module roleAssignments 'modules/role-assignments.bicep' = {
+  name: 'role-assignments'
+  scope: rg
+  params: {
+    principalId: managedIdentity.outputs.principalId
+    acrName: containerRegistry.outputs.name
+    storageAccountName: storage.outputs.name
+  }
+}
+
 // Backend Container App will be deployed separately via GitHub Actions workflow
 // This ensures the latest code is always deployed without requiring Bicep updates
 
@@ -115,3 +137,5 @@ output AZURE_CONTAINER_REGISTRY_NAME string = containerRegistry.outputs.name
 output AZURE_CONTAINER_APPS_ENVIRONMENT_ID string = containerAppsEnvironment.outputs.id
 output AZURE_STORAGE_ACCOUNT_NAME string = storage.outputs.name
 output AZURE_STATIC_WEB_APP_NAME string = frontend.outputs.name
+output AZURE_MANAGED_IDENTITY_ID string = managedIdentity.outputs.id
+output AZURE_MANAGED_IDENTITY_CLIENT_ID string = managedIdentity.outputs.clientId

--- a/infra/modules/container-registry.bicep
+++ b/infra/modules/container-registry.bicep
@@ -15,7 +15,7 @@ resource containerRegistry 'Microsoft.ContainerRegistry/registries@2023-01-01-pr
     name: 'Basic'
   }
   properties: {
-    adminUserEnabled: true
+    adminUserEnabled: false
   }
 }
 

--- a/infra/modules/managed-identity.bicep
+++ b/infra/modules/managed-identity.bicep
@@ -1,0 +1,23 @@
+@description('Name of the managed identity')
+param name string
+
+@description('Location for the managed identity')
+param location string
+
+@description('Tags for the resource')
+param tags object = {}
+
+resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name: name
+  location: location
+  tags: tags
+}
+
+@description('The resource ID of the managed identity')
+output id string = managedIdentity.id
+
+@description('The principal ID of the managed identity')
+output principalId string = managedIdentity.properties.principalId
+
+@description('The client ID of the managed identity')
+output clientId string = managedIdentity.properties.clientId

--- a/infra/modules/role-assignments.bicep
+++ b/infra/modules/role-assignments.bicep
@@ -1,0 +1,39 @@
+@description('Principal ID to assign roles to')
+param principalId string
+
+@description('Name of the ACR to grant pull access to')
+param acrName string
+
+@description('Name of the storage account to grant blob access to')
+param storageAccountName string
+
+// Reference existing resources
+resource acr 'Microsoft.ContainerRegistry/registries@2023-07-01' existing = {
+  name: acrName
+}
+
+resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' existing = {
+  name: storageAccountName
+}
+
+// AcrPull role assignment
+resource acrPullRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(acr.id, principalId, '7f951dda-4ed3-4680-a7ca-43fe172d538d')
+  scope: acr
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d')
+    principalId: principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+// Storage Blob Data Contributor role assignment
+resource storageBlobRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(storageAccount.id, principalId, 'ba92f5b4-2d11-453d-a403-e96b0029c9fe')
+  scope: storageAccount
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ba92f5b4-2d11-453d-a403-e96b0029c9fe')
+    principalId: principalId
+    principalType: 'ServicePrincipal'
+  }
+}


### PR DESCRIPTION
## Summary
- Created a reusable User-Assigned Managed Identity Bicep module (`infra/modules/managed-identity.bicep`) that outputs resource ID, principal ID, and client ID
- Created an additive role assignments module (`infra/modules/role-assignments.bicep`) granting AcrPull and Storage Blob Data Contributor roles to the managed identity
- Disabled ACR admin user (`adminUserEnabled: false`) in the container registry module
- Updated the deploy workflow to use `--registry-identity` instead of `--registry-username`/`--registry-password`, eliminating credential retrieval via `az acr credential show`

## Test plan
- [ ] Deploy to a PR environment and verify the container app pulls images from ACR using the managed identity
- [ ] Confirm `az containerapp up --registry-identity` assigns the user-assigned MI and configures registry auth
- [ ] Verify Bicep validation passes (`az bicep build --file infra/main.bicep` — already validated locally)
- [ ] Check that the Storage Blob Data Contributor role is assigned correctly for future storage access

🤖 Generated with [Claude Code](https://claude.com/claude-code)