### PR TITLE
security: disable public blob access and add SAS URL generation

### DIFF
--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -280,6 +280,7 @@ jobs:
               "AZURE_OPENAI_CHAT_DEPLOYMENT=${{ vars.AZURE_OPENAI_CHAT_DEPLOYMENT || 'gpt-4o-mini' }}" \
               "AZURE_OPENAI_EMBEDDING_DEPLOYMENT=${{ vars.AZURE_OPENAI_EMBEDDING_DEPLOYMENT || 'text-embedding-ada-002' }}" \
               "AZURE_OPENAI_DALLE_DEPLOYMENT=${{ vars.AZURE_OPENAI_DALLE_DEPLOYMENT || 'gpt-image-1-mini' }}" \
+              "AZURE_STORAGE_ACCOUNT_NAME=$STORAGE_ACCOUNT_NAME" \
               "STORAGE_CONNECTION_STRING=$STORAGE_CONNECTION_STRING" \
               "APP_HOST=0.0.0.0" \
               "APP_PORT=8000" \

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -43,6 +43,7 @@ class Settings(BaseSettings):
     content_safety_api_key: str = ""
 
     # Storage Settings
+    azure_storage_account_name: str = ""
     storage_connection_string: str = ""
 
     # CORS Settings

--- a/backend/app/plugins/image_generation_plugin.py
+++ b/backend/app/plugins/image_generation_plugin.py
@@ -3,11 +3,14 @@ Image Generation Plugin for the Agent Framework.
 This plugin provides core image generation capabilities using Azure OpenAI gpt-image-1.
 """
 
+import base64
 import logging
+import uuid
 from typing import Any
 
 # Note: Converted from Agent plugin to direct function calls
 from app.azure_openai_client import azure_openai_client
+from app.services.blob_storage_service import get_blob_storage_service
 
 logger = logging.getLogger(__name__)
 
@@ -50,6 +53,11 @@ class ImageGenerationPlugin:
                 prompt=optimized_prompt, size=size, quality=quality
             )
 
+            # Try uploading to blob storage for a SAS URL instead of a data URI
+            image_url = result.get("image_url")
+            if result.get("success") and result.get("b64_json"):
+                image_url = self._try_upload_to_blob(result["b64_json"]) or image_url
+
             # Store in generation history
             generation_record = {
                 "original_prompt": prompt,
@@ -62,7 +70,7 @@ class ImageGenerationPlugin:
 
             return {
                 "status": "success" if result.get("success") else "error",
-                "image_url": result.get("image_url"),
+                "image_url": image_url,
                 "revised_prompt": result.get("revised_prompt", optimized_prompt),
                 "original_prompt": prompt,
                 "generation_parameters": {
@@ -144,6 +152,25 @@ class ImageGenerationPlugin:
                 "status": "error",
                 "error": f"Failed to get generation history: {str(e)}",
             }
+
+    def _try_upload_to_blob(self, b64_json: str) -> str | None:
+        """Attempt to upload base64 image data to blob storage and return a SAS URL.
+
+        Returns None if blob storage is unavailable, keeping the data URI fallback.
+        """
+        try:
+            blob_service = get_blob_storage_service()
+            image_bytes = base64.b64decode(b64_json)
+            blob_name = f"{uuid.uuid4()}.png"
+            return blob_service.upload_image(
+                container="images",
+                blob_name=blob_name,
+                data=image_bytes,
+                content_type="image/png",
+            )
+        except Exception as e:
+            logger.warning("Blob upload failed, falling back to data URI: %s", e)
+            return None
 
     def _optimize_prompt(
         self, prompt: str, art_style: str = "fantasy", context: str = "RPG"

--- a/backend/app/services/blob_storage_service.py
+++ b/backend/app/services/blob_storage_service.py
@@ -1,0 +1,151 @@
+"""Service for Azure Blob Storage operations with SAS token generation."""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+
+from app.config import get_settings
+
+logger = logging.getLogger(__name__)
+
+# Lazy singleton
+_blob_service: BlobStorageService | None = None
+
+
+class BlobStorageService:
+    """Wraps Azure Blob Storage operations with DefaultAzureCredential auth."""
+
+    def __init__(self) -> None:
+        self._client = None
+        self._configured = False
+
+    def _ensure_client(self) -> bool:
+        """Lazily create the BlobServiceClient."""
+        if self._client is not None:
+            return True
+        if self._configured:
+            return False
+
+        settings = get_settings()
+        self._configured = True
+
+        # Try account name + DefaultAzureCredential first
+        if settings.azure_storage_account_name:
+            try:
+                from azure.identity import DefaultAzureCredential
+                from azure.storage.blob import BlobServiceClient
+
+                account_url = f"https://{settings.azure_storage_account_name}.blob.core.windows.net"
+                self._client = BlobServiceClient(
+                    account_url=account_url,
+                    credential=DefaultAzureCredential(),
+                )
+                logger.info("Blob storage configured via managed identity")
+                return True
+            except Exception as e:
+                logger.warning("Failed to init blob storage via MI: %s", e)
+
+        # Fall back to connection string
+        if settings.storage_connection_string:
+            try:
+                from azure.storage.blob import BlobServiceClient
+
+                self._client = BlobServiceClient.from_connection_string(
+                    settings.storage_connection_string
+                )
+                logger.info("Blob storage configured via connection string")
+                return True
+            except Exception as e:
+                logger.warning("Failed to init blob storage: %s", e)
+
+        logger.info("Blob storage not configured — images will use data URIs")
+        return False
+
+    def upload_image(
+        self,
+        container: str,
+        blob_name: str,
+        data: bytes,
+        content_type: str = "image/png",
+    ) -> str | None:
+        """Upload image bytes and return a SAS URL.
+
+        Returns None if blob storage is not configured.
+        """
+        if not self._ensure_client():
+            return None
+        try:
+            from azure.storage.blob import ContentSettings
+
+            blob_client = self._client.get_blob_client(
+                container=container, blob=blob_name
+            )
+            blob_client.upload_blob(
+                data,
+                overwrite=True,
+                content_settings=ContentSettings(content_type=content_type),
+            )
+
+            # Generate SAS token (1 hour expiry)
+            sas_token = self._generate_sas_token(container, blob_name)
+            if sas_token:
+                return f"{blob_client.url}?{sas_token}"
+
+            # Fallback: return the raw URL (will only work if public access is on)
+            return blob_client.url
+        except Exception as e:
+            logger.warning("Failed to upload image to blob storage: %s", e)
+            return None
+
+    def _generate_sas_token(self, container: str, blob_name: str) -> str | None:
+        """Generate a SAS token for a blob, trying user delegation key first."""
+        from azure.storage.blob import BlobSasPermissions, generate_blob_sas
+
+        settings = get_settings()
+
+        if settings.azure_storage_account_name:
+            # Use user delegation key for MI-based SAS
+            try:
+                delegation_key = self._client.get_user_delegation_key(
+                    key_start_time=datetime.now(UTC),
+                    key_expiry_time=datetime.now(UTC) + timedelta(hours=2),
+                )
+                return generate_blob_sas(
+                    account_name=settings.azure_storage_account_name,
+                    container_name=container,
+                    blob_name=blob_name,
+                    user_delegation_key=delegation_key,
+                    permission=BlobSasPermissions(read=True),
+                    expiry=datetime.now(UTC) + timedelta(hours=1),
+                )
+            except Exception as e:
+                logger.warning(
+                    "User delegation SAS failed, trying account key: %s", e
+                )
+
+        # Fallback: extract account key from connection-string credential
+        account_key = (
+            self._client.credential.account_key
+            if hasattr(self._client.credential, "account_key")
+            else None
+        )
+        if not account_key:
+            return None
+
+        return generate_blob_sas(
+            account_name=self._client.account_name,
+            container_name=container,
+            blob_name=blob_name,
+            account_key=account_key,
+            permission=BlobSasPermissions(read=True),
+            expiry=datetime.now(UTC) + timedelta(hours=1),
+        )
+
+
+def get_blob_storage_service() -> BlobStorageService:
+    """Get or create the singleton BlobStorageService."""
+    global _blob_service  # noqa: PLW0603
+    if _blob_service is None:
+        _blob_service = BlobStorageService()
+    return _blob_service

--- a/infra/modules/storage.bicep
+++ b/infra/modules/storage.bicep
@@ -17,14 +17,14 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
   kind: 'StorageV2'
   properties: {
     accessTier: 'Hot'
-    allowBlobPublicAccess: true
+    allowBlobPublicAccess: false
     allowCrossTenantReplication: false
     allowSharedKeyAccess: true
-    defaultToOAuthAuthentication: false
+    defaultToOAuthAuthentication: true
     minimumTlsVersion: 'TLS1_2'
     networkAcls: {
+      defaultAction: 'Deny'
       bypass: 'AzureServices'
-      defaultAction: 'Allow'
     }
     publicNetworkAccess: 'Enabled'
     supportsHttpsTrafficOnly: true
@@ -61,7 +61,7 @@ resource imagesContainer 'Microsoft.Storage/storageAccounts/blobServices/contain
   parent: blobService
   name: 'images'
   properties: {
-    publicAccess: 'Blob'
+    publicAccess: 'None'
   }
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "azure-ai-projects>=1.0.0,<2.0.0",
     "azure-ai-inference>=1.0.0b1",
     "azure-identity>=1.13.0",
+    "azure-storage-blob>=12.0.0",
     "openai>=1.0,<2.0",
     "opentelemetry-api>=1.20.0",
     "opentelemetry-sdk>=1.20.0",

--- a/uv.lock
+++ b/uv.lock
@@ -123,7 +123,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/29/6533c317b74f707ea28f8d633734dbda2119bbadfc61b2f3640ba835d0f7/alembic-1.18.4-py3-none-any.whl", hash = "sha256:a5ed4adcf6d8a4cb575f3d759f071b03cd6e5c7618eb796cb52497be25bfe19a", size = 263893, upload-time = "2026-02-10T16:00:49.997Z" },
 ]
 
-
 [[package]]
 name = "annotated-doc"
 version = "0.0.4"
@@ -1633,6 +1632,7 @@ dependencies = [
     { name = "azure-ai-inference" },
     { name = "azure-ai-projects" },
     { name = "azure-identity" },
+    { name = "azure-storage-blob" },
     { name = "cryptography" },
     { name = "fastapi" },
     { name = "openai" },
@@ -1674,6 +1674,7 @@ requires-dist = [
     { name = "azure-ai-inference", specifier = ">=1.0.0b1" },
     { name = "azure-ai-projects", specifier = ">=1.0.0,<2.0.0" },
     { name = "azure-identity", specifier = ">=1.13.0" },
+    { name = "azure-storage-blob", specifier = ">=12.0.0" },
     { name = "cryptography", specifier = ">=46.0.5" },
     { name = "fastapi", specifier = ">=0.100.0" },
     { name = "openai", specifier = ">=1.0,<2.0" },


### PR DESCRIPTION
## Summary
- **Disables public blob access** on the Azure storage account (`allowBlobPublicAccess: false`, `defaultToOAuthAuthentication: true`, networkAcls `defaultAction: Deny`)
- **Sets `images` container** `publicAccess` from `Blob` to `None`
- **Adds `BlobStorageService`** with lazy singleton pattern supporting DefaultAzureCredential (managed identity) and connection string fallback
- **Generates user delegation SAS tokens** (1h expiry) for uploaded images, with account key fallback
- **Integrates blob upload** into `ImageGenerationPlugin` — falls back to data URIs when blob storage is unavailable
- Adds `azure-storage-blob` dependency and passes `AZURE_STORAGE_ACCOUNT_NAME` env var in deploy workflow

## Test plan
- [x] All 1079 existing tests pass (1 pre-existing failure in `test_json_logging.py` unrelated to this change)
- [x] Ruff lint passes on all changed files
- [ ] Verify storage account deploys with public access disabled
- [ ] Verify image generation falls back to data URIs when blob storage is not configured (local dev)
- [ ] Verify SAS URL generation works in deployed environment with managed identity

Closes #564

🤖 Generated with [Claude Code](https://claude.com/claude-code)