### PR TITLE
infra: add health probes, environment params, and cost budget

### DIFF
--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -108,6 +108,22 @@ jobs:
           python-version: "3.12"
           enable-cache: true
 
+      - name: Select parameter file
+        id: params
+        run: |
+          # Select environment-specific Bicep parameter file for infrastructure defaults.
+          # Note: The deploy step currently passes all parameters inline. These parameter
+          # files define environment-specific defaults (region, naming) and can be used
+          # with 'az deployment sub create --parameters @<file>' if migrating away from
+          # inline parameters in future.
+          if [ "${{ inputs.is-production }}" = "true" ]; then
+            echo "param_file=infra/parameters/prod.bicepparam" >> $GITHUB_OUTPUT
+            echo "Selected production parameter file"
+          else
+            echo "param_file=infra/parameters/dev.bicepparam" >> $GITHUB_OUTPUT
+            echo "Selected development parameter file"
+          fi
+
       - name: Log in with Azure (Federated Credentials)
         if: steps.check-secrets.outputs.use-federated-auth == 'true'
         uses: azure/login@v2
@@ -326,6 +342,71 @@ jobs:
             sleep 10
           done
           exit 1
+
+      - name: Configure health probes
+        if: steps.backend-deploy.outputs.backend-status == 'success'
+        env:
+          CONTAINER_APP_NAME: ${{ steps.backend-deploy.outputs.container-app-name }}
+          RESOURCE_GROUP: ${{ steps.infrastructure-deploy.outputs.AZURE_RESOURCE_GROUP }}
+        run: |
+          echo "Configuring health probes for $CONTAINER_APP_NAME"
+
+          # Export current app config, inject probes, and apply
+          az containerapp show \
+            --name "$CONTAINER_APP_NAME" \
+            --resource-group "$RESOURCE_GROUP" \
+            -o yaml > /tmp/containerapp.yaml
+
+          # Use Python to patch the YAML with health probe configuration
+          python3 - <<'PYEOF'
+          import yaml, sys
+
+          with open("/tmp/containerapp.yaml") as f:
+              app = yaml.safe_load(f)
+
+          probes = [
+              {
+                  "type": "Liveness",
+                  "httpGet": {"path": "/health", "port": 8000},
+                  "initialDelaySeconds": 30,
+                  "periodSeconds": 30,
+                  "failureThreshold": 3,
+                  "timeoutSeconds": 3,
+              },
+              {
+                  "type": "Readiness",
+                  "httpGet": {"path": "/health", "port": 8000},
+                  "initialDelaySeconds": 5,
+                  "periodSeconds": 10,
+                  "failureThreshold": 3,
+                  "timeoutSeconds": 3,
+              },
+              {
+                  "type": "Startup",
+                  "httpGet": {"path": "/health", "port": 8000},
+                  "initialDelaySeconds": 10,
+                  "periodSeconds": 10,
+                  "failureThreshold": 30,
+                  "timeoutSeconds": 3,
+              },
+          ]
+
+          containers = app["properties"]["template"]["containers"]
+          containers[0]["probes"] = probes
+
+          with open("/tmp/containerapp.yaml", "w") as f:
+              yaml.dump(app, f, default_flow_style=False)
+
+          print("Health probes injected successfully")
+          PYEOF
+
+          az containerapp update \
+            --name "$CONTAINER_APP_NAME" \
+            --resource-group "$RESOURCE_GROUP" \
+            --yaml /tmp/containerapp.yaml
+
+          echo "Health probes configured for $CONTAINER_APP_NAME"
+        timeout-minutes: 5
 
       - name: Build frontend for Static Web App
         id: frontend-build

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -32,6 +32,15 @@ param azureOpenAiDalleDeployment string = 'gpt-image-1-mini'
 @description('Administrator password for the PostgreSQL server (auto-generated if not provided)')
 param databasePassword string = newGuid()
 
+@description('Monthly cost budget amount in billing currency')
+param budgetAmount int = 50
+
+@description('Email addresses for cost budget alert notifications')
+param budgetContactEmails array = []
+
+@description('Budget start date in yyyy-MM-ddT00:00:00Z format. Defaults to the first of the current month.')
+param budgetStartDate string = '${utcNow('yyyy-MM')}-01T00:00:00Z'
+
 // This template should be deployed at the subscription level to create the resource group
 targetScope = 'subscription'
 
@@ -140,6 +149,18 @@ module roleAssignments 'modules/role-assignments.bicep' = {
 
 // Backend Container App will be deployed separately via GitHub Actions workflow
 // This ensures the latest code is always deployed without requiring Bicep updates
+
+// Create cost budget with alert notifications
+module budget 'modules/budget.bicep' = {
+  name: 'budget'
+  scope: rg
+  params: {
+    name: '${environmentName}-monthly-budget'
+    amount: budgetAmount
+    contactEmails: budgetContactEmails
+    startDate: budgetStartDate
+  }
+}
 
 // Create Frontend Static Web App
 module frontend 'modules/frontend.bicep' = {

--- a/infra/modules/budget.bicep
+++ b/infra/modules/budget.bicep
@@ -1,0 +1,46 @@
+@description('Name of the budget')
+param name string
+
+@description('Monthly budget amount in the billing currency')
+param amount int = 50
+
+@description('Email addresses for budget notifications')
+param contactEmails array = []
+
+@description('Budget start date in yyyy-MM-01 format (must be the first of the month)')
+param startDate string
+
+resource budget 'Microsoft.Consumption/budgets@2024-08-01' = {
+  name: name
+  properties: {
+    timePeriod: {
+      startDate: startDate
+    }
+    timeGrain: 'Monthly'
+    amount: amount
+    category: 'Cost'
+    notifications: {
+      actual_GreaterThan_80_Percent: {
+        enabled: true
+        operator: 'GreaterThan'
+        threshold: 80
+        contactEmails: contactEmails
+        thresholdType: 'Actual'
+      }
+      actual_GreaterThan_100_Percent: {
+        enabled: true
+        operator: 'GreaterThan'
+        threshold: 100
+        contactEmails: contactEmails
+        thresholdType: 'Actual'
+      }
+      forecasted_GreaterThan_100_Percent: {
+        enabled: true
+        operator: 'GreaterThan'
+        threshold: 100
+        contactEmails: contactEmails
+        thresholdType: 'Forecasted'
+      }
+    }
+  }
+}

--- a/infra/parameters/dev.bicepparam
+++ b/infra/parameters/dev.bicepparam
@@ -1,0 +1,9 @@
+using '../main.bicep'
+
+// Development environment defaults
+// These provide sensible defaults for development infrastructure sizing.
+// Dynamic values (API keys, endpoints) are passed inline by the deploy workflow.
+
+param environmentName = 'development'
+param location = 'uksouth'
+param resourceGroupName = 'development-rg'

--- a/infra/parameters/prod.bicepparam
+++ b/infra/parameters/prod.bicepparam
@@ -1,0 +1,9 @@
+using '../main.bicep'
+
+// Production environment defaults
+// These provide sensible defaults for production infrastructure sizing.
+// Dynamic values (API keys, endpoints) are passed inline by the deploy workflow.
+
+param environmentName = 'production'
+param location = 'uksouth'
+param resourceGroupName = 'production-rg'


### PR DESCRIPTION
## Summary

- **#480 — Container Apps health probes**: Adds a post-deployment step that exports the Container App YAML, patches it with HTTP-based liveness (30s period), readiness (10s period), and startup (10s period, 30 failure threshold) probes targeting `/health` on port 8000, then applies via `az containerapp update --yaml`. Uses `env:` block for safe variable passing.
- **#565 — Environment-specific Bicep parameter files**: Creates `infra/parameters/prod.bicepparam` and `infra/parameters/dev.bicepparam` with region (`uksouth`) and naming defaults. Adds a workflow step to select the appropriate file based on `is-production`. Existing inline parameter passing is preserved; the files provide defaults for future migration.
- **#566 — Azure cost budget and alert**: Adds `infra/modules/budget.bicep` using `Microsoft.Consumption/budgets@2024-08-01` with three notification thresholds (80% actual, 100% actual, 100% forecasted). Wired into `main.bicep` scoped to the resource group with configurable amount (default GBP 50) and contact emails.

All Bicep files validated locally with `az bicep build`.

## Test plan

- [ ] Verify Bicep validation passes in CI
- [ ] Deploy to a dev environment and confirm the budget resource is created in the resource group
- [ ] Deploy a container app and verify health probes appear in the Azure Portal under Containers > Health probes
- [ ] Confirm the parameter file selection step outputs the correct file path for production vs non-production inputs
- [ ] Verify existing deployment flow is unaffected (health probes step is additive, runs after smoke test)

Closes #480, closes #565, closes #566

🤖 Generated with [Claude Code](https://claude.com/claude-code)