### PR TITLE
feat: add circuit breakers, fix rate limiter, parallelise agent calls

### DIFF
--- a/backend/app/agents/base_agent.py
+++ b/backend/app/agents/base_agent.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+import pybreaker
+
 from app.agent_client_setup import agent_client_manager
 from app.azure_openai_client import AzureOpenAIClient, azure_openai_client
 
@@ -13,6 +15,14 @@ if TYPE_CHECKING:
     from azure.ai.inference import ChatCompletionsClient
 
 logger = logging.getLogger(__name__)
+
+# Module-level circuit breaker for Azure OpenAI calls.
+# Opens after 3 consecutive failures, auto-resets after 60 seconds.
+azure_circuit_breaker = pybreaker.CircuitBreaker(
+    fail_max=3,
+    reset_timeout=60,
+    name="azure_openai",
+)
 
 
 class BaseAgent:
@@ -141,14 +151,24 @@ class BaseAgent:
             self._sdk_thread_ids[session_id] = thread_id
         return thread_id
 
+    @property
+    def _circuit_open(self) -> bool:
+        """Return True if the circuit breaker is open (Azure deemed unavailable)."""
+        return azure_circuit_breaker.current_state == pybreaker.STATE_OPEN
+
     async def _sdk_chat(
         self, session_id: str, user_message: str
     ) -> str | None:
         """Send a user message through the SDK agent and return the response.
 
-        This method handles the full lifecycle: ensure agent exists, get/create
-        a thread for the session, add the user message, run the agent, and
-        return the response text.
+        The call is guarded by the module-level circuit breaker.  When the
+        breaker is open, we skip the Azure call entirely and return ``None``
+        so that callers fall back to deterministic logic.
+
+        Note: pybreaker's ``call_async`` relies on Tornado, which is not
+        available in this project.  Instead we check ``_circuit_open`` before
+        calling and drive ``_handle_success`` / ``_handle_error`` manually
+        for pure-asyncio compatibility.
 
         Args:
             session_id: Game session identifier.
@@ -158,6 +178,31 @@ class BaseAgent:
             The agent's response text, or None if any step fails (caller
             should fall back to direct AzureOpenAIClient).
         """
+        if self._circuit_open:
+            logger.warning(
+                "%s: circuit breaker open — returning fallback", self.agent_name
+            )
+            return None
+
+        try:
+            result = await self._sdk_chat_inner(session_id, user_message)
+            # Record success so half-open transitions back to closed
+            azure_circuit_breaker.state._handle_success()  # noqa: SLF001
+            return result
+        except Exception as exc:
+            # Record failure; pybreaker will trip the breaker after fail_max
+            azure_circuit_breaker.state._handle_error(exc, reraise=False)  # noqa: SLF001
+            logger.warning(
+                "%s: Azure call failed, circuit breaker recorded failure: %s",
+                self.agent_name,
+                exc,
+            )
+            return None
+
+    async def _sdk_chat_inner(
+        self, session_id: str, user_message: str
+    ) -> str | None:
+        """Inner SDK chat logic executed inside the circuit breaker."""
         agent_id = await self._ensure_agent_created()
         if agent_id is None:
             return None

--- a/backend/app/agents/orchestration.py
+++ b/backend/app/agents/orchestration.py
@@ -8,6 +8,7 @@ fires for "general" actions; explicit action types set by the frontend still
 take priority.
 """
 
+import asyncio
 import logging
 import re
 from typing import Any
@@ -104,16 +105,80 @@ def detect_agent_triggers(dm_response: str, player_input: str) -> list[str]:
     return triggers
 
 
+async def _call_combat_mc(
+    player_input: str, state: dict[str, Any]
+) -> tuple[str, Any] | None:
+    """Invoke the Combat MC agent, returning a key-value pair or None on failure."""
+    try:
+        from app.agents.combat_mc_agent import get_combat_mc
+
+        combat_mc = get_combat_mc()
+        action_data: dict[str, Any] = {
+            "type": "attack",
+            "description": player_input,
+            "actor_id": state.get("character_id", "player"),
+            "target_id": state.get("target_id", "enemy_1"),
+        }
+        combat_result = await combat_mc.process_combat_action(
+            encounter_id=state.get("encounter_id", "auto"),
+            action_data=action_data,
+        )
+        return ("combat_update", combat_result)
+    except Exception as exc:
+        logger.error("Combat MC orchestration failed: %s", exc)
+        return None
+
+
+async def _call_narrator(
+    player_input: str, state: dict[str, Any]
+) -> tuple[str, Any] | None:
+    """Invoke the Narrator agent, returning a key-value pair or None on failure."""
+    try:
+        from app.agents.narrator_agent import get_narrator
+
+        narrator = get_narrator()
+        scene_context: dict[str, Any] = {
+            "location": state.get("location", "an unknown place"),
+            "mood": state.get("mood", "neutral"),
+            "recent_events": player_input,
+        }
+        scene = await narrator.describe_scene(scene_context=scene_context)
+        return ("scene_narrative", scene)
+    except Exception as exc:
+        logger.error("Narrator orchestration failed: %s", exc)
+        return None
+
+
+async def _call_scribe(
+    state: dict[str, Any],
+) -> tuple[str, Any] | None:
+    """Invoke the Scribe agent, returning a key-value pair or None on failure."""
+    try:
+        from app.agents.scribe_agent import get_scribe
+
+        scribe = get_scribe()
+        character_id = state.get("character_id", "")
+        if character_id:
+            char_info = await scribe.get_character(character_id)
+        else:
+            char_info = {"note": "No character_id in game state"}
+        return ("character_update", char_info)
+    except Exception as exc:
+        logger.error("Scribe orchestration failed: %s", exc)
+        return None
+
+
 async def orchestrate_specialist_agents(
     triggers: list[str],
     player_input: str,
     game_state: dict[str, Any] | None,
     session_id: str,
 ) -> dict[str, Any]:
-    """Invoke specialist agents based on the detected triggers.
+    """Invoke specialist agents in parallel based on the detected triggers.
 
     Each specialist agent call is wrapped in its own try/except so that a
-    failure in one agent does not prevent the others from running.
+    failure in one agent does not prevent the others from running.  Calls
+    are dispatched concurrently via ``asyncio.gather``.
 
     Args:
         triggers: List of agent identifiers from ``detect_agent_triggers``.
@@ -128,57 +193,25 @@ async def orchestrate_specialist_agents(
     if not triggers:
         return {}
 
-    results: dict[str, Any] = {}
     state = game_state or {}
+    tasks: list[Any] = []
 
     if "combat_mc" in triggers:
-        try:
-            from app.agents.combat_mc_agent import get_combat_mc
-
-            combat_mc = get_combat_mc()
-            # Use a lightweight action dict; full encounter management is
-            # handled separately by the combat workflow endpoints.
-            action_data: dict[str, Any] = {
-                "type": "attack",
-                "description": player_input,
-                "actor_id": state.get("character_id", "player"),
-                "target_id": state.get("target_id", "enemy_1"),
-            }
-            combat_result = await combat_mc.process_combat_action(
-                encounter_id=state.get("encounter_id", "auto"),
-                action_data=action_data,
-            )
-            results["combat_update"] = combat_result
-        except Exception as exc:
-            logger.error("Combat MC orchestration failed: %s", exc)
+        tasks.append(_call_combat_mc(player_input, state))
 
     if "narrator" in triggers:
-        try:
-            from app.agents.narrator_agent import get_narrator
-
-            narrator = get_narrator()
-            scene_context: dict[str, Any] = {
-                "location": state.get("location", "an unknown place"),
-                "mood": state.get("mood", "neutral"),
-                "recent_events": player_input,
-            }
-            scene = await narrator.describe_scene(scene_context=scene_context)
-            results["scene_narrative"] = scene
-        except Exception as exc:
-            logger.error("Narrator orchestration failed: %s", exc)
+        tasks.append(_call_narrator(player_input, state))
 
     if "scribe" in triggers:
-        try:
-            from app.agents.scribe_agent import get_scribe
+        tasks.append(_call_scribe(state))
 
-            scribe = get_scribe()
-            character_id = state.get("character_id", "")
-            if character_id:
-                char_info = await scribe.get_character(character_id)
-            else:
-                char_info = {"note": "No character_id in game state"}
-            results["character_update"] = char_info
-        except Exception as exc:
-            logger.error("Scribe orchestration failed: %s", exc)
+    # Run all agent calls concurrently; individual failures return None
+    raw_results = await asyncio.gather(*tasks, return_exceptions=False)
+
+    results: dict[str, Any] = {}
+    for item in raw_results:
+        if item is not None:
+            key, value = item
+            results[key] = value
 
     return results

--- a/backend/app/api/routes/_shared.py
+++ b/backend/app/api/routes/_shared.py
@@ -1,12 +1,26 @@
 """Shared utilities for domain route modules."""
 
 from slowapi import Limiter
-from slowapi.util import get_remote_address
+from starlette.requests import Request
 
 from app.image_budget import ImageBudgetTracker
 
-# Rate limiter for AI-calling endpoints
-limiter = Limiter(key_func=get_remote_address)
+
+def _get_real_client_ip(request: Request) -> str:
+    """Extract the real client IP, respecting X-Forwarded-For for Container Apps."""
+    forwarded = request.headers.get("X-Forwarded-For")
+    if forwarded:
+        # X-Forwarded-For may contain a comma-separated chain; leftmost is the client
+        return forwarded.split(",")[0].strip()
+    if request.client:
+        return request.client.host
+    return "127.0.0.1"
+
+
+# Singleton rate limiter — all route modules MUST import this instance
+# instead of creating their own Limiter().
+# Default limit: 60 requests/minute per IP.
+limiter = Limiter(key_func=_get_real_client_ip, default_limits=["60/minute"])
 
 # ---------------------------------------------------------------------------
 # Per-session image budget – initialised from config on first use

--- a/backend/app/api/routes/ai_routes.py
+++ b/backend/app/api/routes/ai_routes.py
@@ -88,7 +88,7 @@ async def get_ai_assistance(request: AIAssistanceRequest) -> dict[str, Any]:
 
 
 @router.post("/campaign/ai-generate", response_model=AIContentGenerationResponse)
-@limiter.limit("10/minute")
+@limiter.limit("30/minute")
 async def generate_ai_content(  # noqa: ARG001
     request: Request,
     request_body: AIContentGenerationRequest,
@@ -146,7 +146,7 @@ async def generate_ai_content(  # noqa: ARG001
 
 
 @router.post("/generate-image", response_model=dict[str, Any])
-@limiter.limit("10/minute")
+@limiter.limit("5/minute")
 async def generate_image(  # noqa: ARG001
     request: Request, image_request: dict[str, Any],
 ) -> dict[str, Any]:
@@ -199,7 +199,7 @@ async def generate_image(  # noqa: ARG001
 
 
 @router.post("/battle-map", response_model=dict[str, Any])
-@limiter.limit("10/minute")
+@limiter.limit("5/minute")
 async def generate_battle_map(  # noqa: ARG001
     request: Request, map_request: dict[str, Any],
 ) -> dict[str, Any]:

--- a/backend/app/api/routes/session_routes.py
+++ b/backend/app/api/routes/session_routes.py
@@ -35,7 +35,7 @@ router = APIRouter(tags=["sessions"])
 
 
 @router.post("/input", response_model=GameResponse)
-@limiter.limit("10/minute")
+@limiter.limit("30/minute")
 async def process_player_input(  # noqa: ARG001
     request: Request, player_input: PlayerInput,
 ) -> GameResponse:
@@ -147,7 +147,7 @@ async def process_player_input(  # noqa: ARG001
 
 
 @router.post("/campaign/generate-world", response_model=dict[str, Any])
-@limiter.limit("10/minute")
+@limiter.limit("30/minute")
 async def generate_campaign_world(  # noqa: ARG001
     request: Request, campaign_data: dict[str, Any],
 ) -> dict[str, Any]:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,9 +15,8 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from pythonjsonlogger.json import JsonFormatter
-from slowapi import Limiter, _rate_limit_exceeded_handler
+from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
-from slowapi.util import get_remote_address
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import Response
 
@@ -25,6 +24,7 @@ from app.api import websocket_routes
 
 # Local imports
 from app.api.routes import all_routers
+from app.api.routes._shared import limiter
 from app.config import init_settings
 from app.middleware.prompt_shield_middleware import PromptShieldMiddleware
 from app.services.campaign_service import campaign_service
@@ -44,9 +44,6 @@ logging.root.handlers = [_handler]
 logging.root.setLevel(_log_level)
 
 logger = logging.getLogger(__name__)
-
-# Rate limiter configuration
-limiter = Limiter(key_func=get_remote_address)
 
 
 class SecurityHeadersMiddleware(BaseHTTPMiddleware):
@@ -140,8 +137,48 @@ app.include_router(websocket_routes.router)
 
 # Health check endpoint
 @app.get("/health")
-async def health_check() -> dict[str, Any]:
+@limiter.limit("120/minute")
+async def health_check(request: Request) -> dict[str, Any]:  # noqa: ARG001
     return {"status": "ok", "version": "0.1.0"}
+
+
+@app.get("/health/dependencies")
+@limiter.limit("120/minute")
+async def health_dependencies(request: Request) -> dict[str, str]:  # noqa: ARG001
+    """Return the health status of external dependencies and the circuit breaker."""
+    from app.agent_client_setup import agent_client_manager
+    from app.agents.base_agent import azure_circuit_breaker
+
+    # Azure OpenAI status
+    cb_state = azure_circuit_breaker.current_state  # "closed", "open", "half-open"
+    if agent_client_manager.is_fallback_mode():
+        azure_status = "unavailable"
+    elif cb_state == "open":
+        azure_status = "degraded"
+    else:
+        azure_status = "healthy"
+
+    # Database status — attempt a lightweight query
+    try:
+        from sqlalchemy import text
+
+        from app.database import get_session_local
+
+        session_factory = get_session_local()
+        db = session_factory()
+        try:
+            db.execute(text("SELECT 1"))
+            db_status = "healthy"
+        finally:
+            db.close()
+    except Exception:
+        db_status = "unavailable"
+
+    return {
+        "azure_openai": azure_status,
+        "database": db_status,
+        "circuit_breaker_state": cb_state,
+    }
 
 
 # Root endpoint

--- a/backend/app/routers/campaign.py
+++ b/backend/app/routers/campaign.py
@@ -5,10 +5,9 @@ from datetime import datetime
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, Request, status
-from slowapi import Limiter
-from slowapi.util import get_remote_address
 
 from app.agents.narrator_agent import get_narrator
+from app.api.routes._shared import limiter
 from app.config import ConfigDep
 from app.models.game_models import (
     NPC,
@@ -29,8 +28,6 @@ from app.models.game_models import (
 from app.services.campaign_service import campaign_service
 
 logger = logging.getLogger(__name__)
-
-limiter = Limiter(key_func=get_remote_address)
 
 router = APIRouter(tags=["campaign"])
 
@@ -261,7 +258,7 @@ async def get_ai_assistance(request: AIAssistanceRequest) -> AIAssistanceRespons
 
 
 @router.post("/campaign/ai-generate", response_model=AIContentGenerationResponse)
-@limiter.limit("10/minute")
+@limiter.limit("30/minute")
 async def generate_ai_content(  # noqa: ARG001
     request: Request,
     request_body: AIContentGenerationRequest,
@@ -321,7 +318,7 @@ async def generate_ai_content(  # noqa: ARG001
 
 
 @router.post("/campaign/generate-world", response_model=dict[str, Any])
-@limiter.limit("10/minute")
+@limiter.limit("30/minute")
 async def generate_campaign_world(request: Request, campaign_data: dict[str, Any]) -> dict[str, Any]:  # noqa: ARG001
     """Generate world description and setting for a new campaign."""
     try:

--- a/backend/app/routers/images.py
+++ b/backend/app/routers/images.py
@@ -4,16 +4,13 @@ import logging
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, Request, status
-from slowapi import Limiter
-from slowapi.util import get_remote_address
 
 from app.agents.artist_agent import get_artist
 from app.agents.combat_cartographer_agent import get_combat_cartographer
+from app.api.routes._shared import limiter
 from app.image_budget import ImageBudgetTracker
 
 logger = logging.getLogger(__name__)
-
-limiter = Limiter(key_func=get_remote_address)
 
 router = APIRouter(tags=["images"])
 
@@ -38,7 +35,7 @@ def _get_image_budget() -> ImageBudgetTracker:
 
 
 @router.post("/generate-image", response_model=dict[str, Any])
-@limiter.limit("10/minute")
+@limiter.limit("5/minute")
 async def generate_image(  # noqa: ARG001
     request: Request, image_request: dict[str, Any],
 ) -> dict[str, Any]:
@@ -90,7 +87,7 @@ async def generate_image(  # noqa: ARG001
 
 
 @router.post("/battle-map", response_model=dict[str, Any])
-@limiter.limit("10/minute")
+@limiter.limit("5/minute")
 async def generate_battle_map(  # noqa: ARG001
     request: Request, map_request: dict[str, Any],
 ) -> dict[str, Any]:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -3,9 +3,14 @@ Test configuration and utilities for improved configuration handling.
 """
 
 import pytest
+from app.api.routes._shared import limiter
 from app.config import Settings, get_config
 from app.main import app
 from fastapi.testclient import TestClient
+
+# Disable the rate limiter globally during tests so that endpoint tests
+# exercise business logic without being blocked by per-IP rate limits.
+limiter.enabled = False
 
 # Import factories for use in tests (gracefully handle missing dependencies)
 try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,8 @@ dependencies = [
     "psycopg2-binary>=2.9.0",
     # Security & Rate Limiting
     "slowapi>=0.1.9",
+    # Circuit breaker for Azure OpenAI resilience
+    "pybreaker>=1.0.0",
     # HTTP client for external services
     "aiohttp>=3.9.0",
     # Utilities

--- a/uv.lock
+++ b/uv.lock
@@ -1252,6 +1252,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pybreaker"
+version = "1.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/89/fbf98e383f1ec6d117af2cd983efdb3eb7018b63834c427025764194cac2/pybreaker-1.4.1.tar.gz", hash = "sha256:8df2d245c73ba40c8242c56ffb4f12138fbadc23e296224740c2028ea9dc1178", size = 15555, upload-time = "2025-09-21T15:12:04.499Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/75/e64d3d40a741e2be21d69154f4e5c43a66f0c603c5ef11f49e01429a5932/pybreaker-1.4.1-py3-none-any.whl", hash = "sha256:b4dab4a05195b7f2a64a6c1a6c4ba7a96534ef56ea7210e6bcb59f28897160e0", size = 12915, upload-time = "2025-09-21T15:12:02.284Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1639,6 +1648,7 @@ dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-sdk" },
     { name = "psycopg2-binary" },
+    { name = "pybreaker" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
@@ -1683,6 +1693,7 @@ requires-dist = [
     { name = "opentelemetry-sdk", specifier = ">=1.20.0" },
     { name = "psycopg2-binary", specifier = ">=2.9.0" },
     { name = "psycopg2-binary", marker = "extra == 'postgres'", specifier = ">=2.9.6" },
+    { name = "pybreaker", specifier = ">=1.0.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },


### PR DESCRIPTION
## Summary
- **Circuit breakers (#561):** Added `pybreaker` to wrap Azure OpenAI SDK calls in `base_agent.py` with a module-level circuit breaker (3 failures to open, 60s reset). Added `/health/dependencies` endpoint exposing Azure, database, and breaker state.
- **Rate limiter consolidation (#562):** Removed duplicate `Limiter()` instances from `routers/campaign.py` and `routers/images.py`, consolidated to the singleton in `_shared.py` with `X-Forwarded-For` support. Applied tiered limits: AI endpoints 30/min, image generation 5/min, health 120/min, default 60/min.
- **Parallel agent orchestration (#570):** Refactored `orchestrate_specialist_agents()` in `orchestration.py` to dispatch specialist agents concurrently via `asyncio.gather()` with per-agent error isolation.

Closes #561, closes #562, closes #570

## Test plan
- [x] All 1064 existing tests pass (6 skipped, 3 xfailed)
- [x] Rate limiter disabled in test conftest to prevent flaky endpoint tests
- [x] Ruff clean on all changed files (remaining E501 errors are pre-existing long string literals)
- [ ] Manual verification of `/health/dependencies` endpoint returning correct circuit breaker state
- [ ] Manual verification that rate limits apply correctly in Container Apps with X-Forwarded-For

🤖 Generated with [Claude Code](https://claude.com/claude-code)