### PR TITLE
feat: wire conversation history, agents, and rules engine (closes #416)

### DIFF
--- a/backend/app/agents/combat_mc_agent.py
+++ b/backend/app/agents/combat_mc_agent.py
@@ -442,14 +442,23 @@ class CombatMCAgent(BaseAgent):
 
         if action_type == "attack":
             # Simple attack resolution using fallback mechanics
-            attack_bonus = action_data.get("attack_bonus", 3)  # Default +3 attack
+            # Prefer attack_bonus from game context (populated by #416 wiring)
+            attack_bonus = action_data.get("attack_bonus", 3)
             target_ac = action_data.get("target_ac", 12)  # Default AC 12
 
             attack_roll = self._fallback_roll_d20(attack_bonus)
 
             if attack_roll["total"] >= target_ac:
-                # Hit - calculate damage
-                damage_dice = action_data.get("damage", "1d6+2")
+                # Hit - calculate damage.  Prefer damage_dice from game
+                # context; fall back to legacy "damage" key for compat.
+                damage_dice = action_data.get(
+                    "damage_dice", action_data.get("damage", "1d6+2")
+                )
+                # Append modifier if provided and not already in notation
+                damage_modifier = action_data.get("damage_modifier", 0)
+                if damage_modifier and "+" not in damage_dice and "-" not in damage_dice:
+                    sign = "+" if damage_modifier >= 0 else ""
+                    damage_dice = f"{damage_dice}{sign}{damage_modifier}"
                 damage_result = self._fallback_roll_damage(damage_dice)
 
                 result.update(
@@ -564,12 +573,20 @@ class CombatMCAgent(BaseAgent):
     ) -> dict[str, Any]:
         """Process an attack action using the rules engine plugin."""
         try:
-            # Get attack parameters
+            # Get attack parameters.  Prefer keys populated by game context
+            # (#416 wiring); fall back to legacy keys for backward compat.
             attack_bonus = action_data.get("attack_bonus", 3)
             target_ac = action_data.get("target_ac", 12)
             advantage = action_data.get("advantage", False)
             disadvantage = action_data.get("disadvantage", False)
-            damage_dice = action_data.get("damage", "1d6+2")
+            damage_dice = action_data.get(
+                "damage_dice", action_data.get("damage", "1d6+2")
+            )
+            # Append damage modifier from character stats if not in notation
+            damage_modifier = action_data.get("damage_modifier", 0)
+            if damage_modifier and "+" not in damage_dice and "-" not in damage_dice:
+                sign = "+" if damage_modifier >= 0 else ""
+                damage_dice = f"{damage_dice}{sign}{damage_modifier}"
 
             # Use the rules engine to resolve the attack
             attack_result = rules_plugin.resolve_attack(

--- a/backend/app/agents/dungeon_master_agent.py
+++ b/backend/app/agents/dungeon_master_agent.py
@@ -142,11 +142,15 @@ class DungeonMasterAgent(BaseAgent):
             "the single point of coordination for the entire game experience."
         )
 
-    def _get_or_create_thread(self, session_id: str) -> list[dict[str, str]]:
+    def _get_or_create_thread(
+        self, session_id: str, campaign_id: str | None = None
+    ) -> list[dict[str, str]]:
         """Return the message thread for a session, creating one if needed.
 
         Checks the in-memory cache first, then the database. Creates a new
-        DB record if neither contains an existing thread.
+        DB record if neither contains an existing thread.  When *campaign_id*
+        is provided the thread row is associated with the campaign so that
+        conversation history can be resumed when the campaign is loaded later.
         """
         if session_id in self._threads:
             return self._threads[session_id]
@@ -163,6 +167,10 @@ class DungeonMasterAgent(BaseAgent):
                     .first()
                 )
                 if thread_row:
+                    # Ensure campaign_id is set on existing threads
+                    if campaign_id and not thread_row.campaign_id:
+                        thread_row.campaign_id = campaign_id
+                        db.commit()
                     self._threads[session_id] = list(thread_row.messages or [])
                     return self._threads[session_id]
 
@@ -170,6 +178,7 @@ class DungeonMasterAgent(BaseAgent):
                 new_thread = ConversationThread(
                     id=str(uuid.uuid4()),
                     session_id=session_id,
+                    campaign_id=campaign_id,
                     agent_name="DM",
                     messages=[],
                 )
@@ -284,7 +293,8 @@ class DungeonMasterAgent(BaseAgent):
         session_id = context.get("session_id") or context.get(
             "campaign_id", "default"
         )
-        thread = self._get_or_create_thread(session_id)
+        campaign_id = context.get("campaign_id")
+        thread = self._get_or_create_thread(session_id, campaign_id=campaign_id)
 
         # Build the user message (may include character name prefix)
         user_message = user_input
@@ -384,7 +394,8 @@ class DungeonMasterAgent(BaseAgent):
         session_id = context.get("session_id") or context.get(
             "campaign_id", "default"
         )
-        thread = self._get_or_create_thread(session_id)
+        campaign_id = context.get("campaign_id")
+        thread = self._get_or_create_thread(session_id, campaign_id=campaign_id)
 
         # Build the user message (may include character name prefix)
         user_message = user_input

--- a/backend/app/agents/orchestration.py
+++ b/backend/app/agents/orchestration.py
@@ -108,7 +108,12 @@ def detect_agent_triggers(dm_response: str, player_input: str) -> list[str]:
 async def _call_combat_mc(
     player_input: str, state: dict[str, Any]
 ) -> tuple[str, Any] | None:
-    """Invoke the Combat MC agent, returning a key-value pair or None on failure."""
+    """Invoke the Combat MC agent, returning a key-value pair or None on failure.
+
+    Passes the character's equipped weapon stats, attack bonus, and damage
+    modifier from the game context so that combat resolution uses the actual
+    character equipment rather than generic defaults.
+    """
     try:
         from app.agents.combat_mc_agent import get_combat_mc
 
@@ -118,6 +123,13 @@ async def _call_combat_mc(
             "description": player_input,
             "actor_id": state.get("character_id", "player"),
             "target_id": state.get("target_id", "enemy_1"),
+            # Carry over weapon/combat stats from game context (#416)
+            "attack_bonus": state.get("attack_bonus", 0),
+            "damage_dice": state.get("equipped_weapon_damage", "1d4"),
+            "damage_modifier": state.get("damage_modifier", 0),
+            "weapon_name": state.get("equipped_weapon_name", ""),
+            "weapon_properties": state.get("equipped_weapon_properties", []),
+            "proficiency_bonus": state.get("proficiency_bonus", 2),
         }
         combat_result = await combat_mc.process_combat_action(
             encounter_id=state.get("encounter_id", "auto"),

--- a/backend/app/api/routes/session_routes.py
+++ b/backend/app/api/routes/session_routes.py
@@ -27,6 +27,7 @@ from app.models.game_models import (
     PlayerInput,
 )
 from app.services.campaign_service import campaign_service
+from app.services.game_context_service import build_game_context, build_state_updates
 from app.services.prompt_shield_service import prompt_shield_service
 
 logger = logging.getLogger(__name__)
@@ -70,14 +71,13 @@ async def process_player_input(  # noqa: ARG001
                 "level": 1,
             }
 
-        # Create context for the Dungeon Master agent
-        context = {
-            "character_id": player_input.character_id,
-            "campaign_id": player_input.campaign_id,
-            "character_name": character.get("name", "Adventurer"),
-            "character_class": character.get("class", "Fighter"),
-            "character_level": str(character.get("level", 1)),
-        }
+        # Build rich game context from campaign state, character stats,
+        # equipment, and combat-derived values (Step 1 of #416).
+        context = build_game_context(
+            character_id=player_input.character_id,
+            campaign_id=player_input.campaign_id,
+            character_data=character,
+        )
 
         # Process the input through the Dungeon Master agent
         dm_response = await get_dungeon_master().process_input(
@@ -99,9 +99,9 @@ async def process_player_input(  # noqa: ARG001
             )
             logger.info("Specialist agent results: %s", list(specialist_results.keys()))
 
-        # Merge specialist outputs into state_updates so the frontend
-        # receives them alongside the DM narrative.
-        merged_state = dm_response.get("state_updates", {})
+        # Build enriched state_updates with character HP, conditions,
+        # equipped weapon, and spell slots (Step 5 of #416).
+        merged_state = build_state_updates(context, dm_response)
         merged_state.update(specialist_results)
 
         # If combat was triggered by orchestration, surface it as combat_updates

--- a/backend/app/services/game_context_service.py
+++ b/backend/app/services/game_context_service.py
@@ -1,0 +1,356 @@
+"""Service for building game context during /input processing.
+
+Loads campaign state, character stats, equipment, and conditions to
+pass to the DM agent and orchestration layer. This is the integration
+glue that connects the campaign, character, inventory, and rules
+engine systems during live gameplay.
+"""
+
+import logging
+from typing import Any
+
+from app.database import get_session_context
+from app.models.db_models import Character as CharacterDB
+from app.rules_engine import (
+    calculate_ac,
+    get_proficiency_bonus,
+    get_weapon_stats,
+)
+from app.services.campaign_service import campaign_service
+
+logger = logging.getLogger(__name__)
+
+
+def _ability_modifier(score: int) -> int:
+    """Calculate the ability modifier for a given ability score."""
+    return (score - 10) // 2
+
+
+def load_character_state(character_id: str) -> dict[str, Any]:
+    """Load full character state from the database.
+
+    Returns a dict with stats, equipment, spell slots, conditions,
+    and combat-relevant derived values.
+    """
+    try:
+        with get_session_context() as db:
+            char_row = (
+                db.query(CharacterDB)
+                .filter(CharacterDB.id == character_id)
+                .first()
+            )
+            if not char_row or not char_row.data:
+                return {}
+
+            data: dict[str, Any] = dict(char_row.data)
+            data.setdefault("id", char_row.id)
+            data.setdefault("name", char_row.name)
+
+            # Derive combat-relevant values
+            abilities = data.get("abilities", {})
+            level = data.get("level", 1)
+            proficiency_bonus = get_proficiency_bonus(level)
+            data["proficiency_bonus"] = proficiency_bonus
+
+            # Determine equipped weapon stats
+            equipped_weapon = _get_equipped_weapon(data)
+            if equipped_weapon:
+                data["equipped_weapon"] = equipped_weapon
+
+            # Calculate AC from equipment
+            equipped_armor = _get_equipped_armor_name(data)
+            shield_equipped = _has_shield(data)
+            dex_mod = _ability_modifier(abilities.get("dexterity", 10))
+            data["computed_ac"] = calculate_ac(equipped_armor, shield_equipped, dex_mod)
+
+            return data
+    except Exception as e:
+        logger.warning("Failed to load character state for %s: %s", character_id, e)
+        return {}
+
+
+def _get_equipped_weapon(char_data: dict[str, Any]) -> dict[str, Any] | None:
+    """Determine the character's equipped weapon and return its stats.
+
+    Checks structured_inventory.equipment.main_hand first, then falls
+    back to the first equipped weapon-type item in structured_inventory.items.
+    """
+    inv = char_data.get("structured_inventory", {})
+    if isinstance(inv, dict):
+        equipment = inv.get("equipment", {})
+        items = inv.get("items", [])
+
+        # Check main_hand slot
+        main_hand_id = equipment.get("main_hand") if isinstance(equipment, dict) else None
+
+        if main_hand_id and isinstance(items, list):
+            for item in items:
+                if isinstance(item, dict) and item.get("id") == main_hand_id:
+                    weapon_name = item.get("name", "")
+                    weapon_stats = get_weapon_stats(weapon_name)
+                    return {
+                        "name": weapon_name,
+                        **weapon_stats,
+                    }
+
+        # Fallback: first equipped weapon-type item
+        if isinstance(items, list):
+            for item in items:
+                if (
+                    isinstance(item, dict)
+                    and item.get("equipped")
+                    and item.get("item_type") == "weapon"
+                ):
+                    weapon_name = item.get("name", "")
+                    weapon_stats = get_weapon_stats(weapon_name)
+                    return {
+                        "name": weapon_name,
+                        **weapon_stats,
+                    }
+
+    return None
+
+
+def _get_equipped_armor_name(char_data: dict[str, Any]) -> str | None:
+    """Return the name of the equipped armor, or None."""
+    inv = char_data.get("structured_inventory", {})
+    if isinstance(inv, dict):
+        equipment = inv.get("equipment", {})
+        items = inv.get("items", [])
+
+        armor_id = equipment.get("armor") if isinstance(equipment, dict) else None
+        if armor_id and isinstance(items, list):
+            for item in items:
+                if isinstance(item, dict) and item.get("id") == armor_id:
+                    return item.get("name")
+
+        # Fallback: first equipped armor-type item
+        if isinstance(items, list):
+            for item in items:
+                if (
+                    isinstance(item, dict)
+                    and item.get("equipped")
+                    and item.get("item_type") == "armor"
+                ):
+                    return item.get("name")
+
+    return None
+
+
+def _has_shield(char_data: dict[str, Any]) -> bool:
+    """Check if character has a shield equipped."""
+    inv = char_data.get("structured_inventory", {})
+    if isinstance(inv, dict):
+        equipment = inv.get("equipment", {})
+        items = inv.get("items", [])
+
+        off_hand_id = equipment.get("off_hand") if isinstance(equipment, dict) else None
+        if off_hand_id and isinstance(items, list):
+            for item in items:
+                if (
+                    isinstance(item, dict)
+                    and item.get("id") == off_hand_id
+                    and item.get("item_type") == "shield"
+                ):
+                    return True
+
+        # Fallback: any equipped shield-type item
+        if isinstance(items, list):
+            for item in items:
+                if (
+                    isinstance(item, dict)
+                    and item.get("equipped")
+                    and item.get("item_type") == "shield"
+                ):
+                    return True
+
+    return False
+
+
+def load_campaign_state(campaign_id: str) -> dict[str, Any]:
+    """Load campaign state for context enrichment.
+
+    Returns a dict with campaign metadata, current location, and any
+    active combat state.
+    """
+    try:
+        campaign = campaign_service.get_campaign(campaign_id)
+        if campaign is None:
+            return {}
+
+        return {
+            "id": campaign.id,
+            "name": campaign.name,
+            "setting": campaign.setting,
+            "tone": campaign.tone,
+            "current_location": campaign.current_location or "",
+            "world_description": campaign.world_description or "",
+        }
+    except Exception as e:
+        logger.warning("Failed to load campaign state for %s: %s", campaign_id, e)
+        return {}
+
+
+def build_game_context(
+    character_id: str,
+    campaign_id: str,
+    character_data: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build the full game context for the DM agent and orchestration layer.
+
+    This combines character state, campaign state, and derived combat
+    values into a single context dict that flows through the /input pipeline.
+
+    Args:
+        character_id: The player's character ID.
+        campaign_id: The active campaign ID.
+        character_data: Optional pre-loaded character data (avoids double-load).
+
+    Returns:
+        Dict containing all context needed by the DM agent and specialists.
+    """
+    # Load character state
+    if character_data and isinstance(character_data, dict) and character_data.get("level"):
+        char_state = dict(character_data)
+    else:
+        char_state = load_character_state(character_id)
+
+    # Derive equipment-based values if not already present.
+    # load_character_state() populates these, but when caller supplies
+    # character_data directly we need to compute them here.
+    if "equipped_weapon" not in char_state:
+        equipped = _get_equipped_weapon(char_state)
+        if equipped:
+            char_state["equipped_weapon"] = equipped
+    if "computed_ac" not in char_state:
+        abilities_for_ac = char_state.get("abilities", {})
+        dex_for_ac = (
+            _ability_modifier(abilities_for_ac.get("dexterity", 10))
+            if isinstance(abilities_for_ac, dict)
+            else 0
+        )
+        char_state["computed_ac"] = calculate_ac(
+            _get_equipped_armor_name(char_state),
+            _has_shield(char_state),
+            dex_for_ac,
+        )
+
+    # Load campaign state
+    campaign_state = load_campaign_state(campaign_id) if campaign_id else {}
+
+    # Extract ability scores for convenience
+    abilities = char_state.get("abilities", {})
+    if isinstance(abilities, dict):
+        str_mod = _ability_modifier(abilities.get("strength", 10))
+        dex_mod = _ability_modifier(abilities.get("dexterity", 10))
+    else:
+        str_mod = 0
+        dex_mod = 0
+
+    # Build the equipped weapon attack context
+    equipped_weapon = char_state.get("equipped_weapon", {})
+    weapon_properties = equipped_weapon.get("properties", [])
+    level = char_state.get("level", 1)
+    proficiency_bonus = get_proficiency_bonus(level)
+
+    # Determine attack modifier: finesse/ranged use DEX, others use STR
+    is_finesse = "finesse" in weapon_properties
+    is_ranged = "ammunition" in weapon_properties
+    if is_ranged or is_finesse:
+        ability_mod = max(str_mod, dex_mod) if is_finesse else dex_mod
+    else:
+        ability_mod = str_mod
+
+    attack_bonus = ability_mod + proficiency_bonus
+    damage_modifier = ability_mod
+
+    # Extract HP
+    hp = char_state.get("hit_points", {})
+    if isinstance(hp, dict):
+        current_hp = hp.get("current", 0)
+        max_hp = hp.get("maximum", 0)
+    else:
+        current_hp = 0
+        max_hp = 0
+
+    # Extract conditions
+    conditions = char_state.get("conditions", [])
+
+    # Extract spell slots
+    spellcasting = char_state.get("spellcasting", {})
+    spell_slots = None
+    if isinstance(spellcasting, dict):
+        spell_slots = spellcasting.get("spell_slots")
+
+    context = {
+        # Identity
+        "character_id": character_id,
+        "campaign_id": campaign_id,
+        "character_name": char_state.get("name", "Adventurer"),
+        "character_class": char_state.get("character_class", "Fighter"),
+        "character_level": str(level),
+        # Combat stats
+        "current_hp": current_hp,
+        "max_hp": max_hp,
+        "armor_class": char_state.get("computed_ac", char_state.get("armor_class", 10)),
+        "proficiency_bonus": proficiency_bonus,
+        "conditions": conditions,
+        # Weapon info (for combat orchestration)
+        "equipped_weapon_name": equipped_weapon.get("name", ""),
+        "equipped_weapon_damage": equipped_weapon.get("damage_dice", "1d4"),
+        "equipped_weapon_properties": weapon_properties,
+        "attack_bonus": attack_bonus,
+        "damage_modifier": damage_modifier,
+        # Spell info
+        "spell_slots": spell_slots,
+        # Campaign context
+        "location": campaign_state.get("current_location", ""),
+        "setting": campaign_state.get("setting", ""),
+        "tone": campaign_state.get("tone", "heroic"),
+    }
+
+    return context
+
+
+def build_state_updates(
+    context: dict[str, Any],
+    dm_response: dict[str, Any],
+) -> dict[str, Any]:
+    """Build the state_updates section for the GameResponse.
+
+    Enriches the DM response with current game state so the frontend
+    can display HP, conditions, inventory changes, etc.
+
+    Args:
+        context: The game context built by build_game_context.
+        dm_response: The raw response from the DM agent.
+
+    Returns:
+        Dict of state updates to include in GameResponse.
+    """
+    state = dict(dm_response.get("state_updates", {}))
+
+    # Always include current character state
+    state["character_state"] = {
+        "current_hp": context.get("current_hp", 0),
+        "max_hp": context.get("max_hp", 0),
+        "armor_class": context.get("armor_class", 10),
+        "conditions": context.get("conditions", []),
+        "level": int(context.get("character_level", 1)),
+    }
+
+    # Include equipped weapon info if available
+    weapon_name = context.get("equipped_weapon_name")
+    if weapon_name:
+        state["equipped_weapon"] = {
+            "name": weapon_name,
+            "damage_dice": context.get("equipped_weapon_damage", "1d4"),
+            "attack_bonus": context.get("attack_bonus", 0),
+        }
+
+    # Include spell slots if available
+    spell_slots = context.get("spell_slots")
+    if spell_slots:
+        state["spell_slots"] = spell_slots
+
+    return state

--- a/backend/tests/test_game_engine_wiring.py
+++ b/backend/tests/test_game_engine_wiring.py
@@ -1,0 +1,522 @@
+"""
+Tests for game engine wiring (issue #416).
+
+Covers:
+- Game context flows through the /input endpoint (build_game_context integration)
+- Campaign ID is set on conversation threads
+- Combat resolution uses character equipment from game context
+- State updates include character HP, conditions, and weapon info
+"""
+
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+from app.database import Base
+from app.models.db_models import ConversationThread
+from app.rules_engine import get_weapon_stats
+from app.services.game_context_service import (
+    build_game_context,
+    build_state_updates,
+)
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+# ---------------------------------------------------------------------------
+# In-memory DB fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="function")
+def db_session():
+    """Create a fresh in-memory SQLite database for each test."""
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    session_factory = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    db = session_factory()
+    try:
+        yield db
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture()
+def fighter_character_data() -> dict:
+    """Character data dict representing a level-3 Fighter with a longsword."""
+    return {
+        "id": "char-fighter-1",
+        "name": "Thorn Ironforge",
+        "race": "human",
+        "character_class": "fighter",
+        "level": 3,
+        "experience": 1000,
+        "abilities": {
+            "strength": 16,
+            "dexterity": 12,
+            "constitution": 14,
+            "intelligence": 10,
+            "wisdom": 10,
+            "charisma": 8,
+        },
+        "hit_points": {"current": 28, "maximum": 31},
+        "armor_class": 16,
+        "proficiency_bonus": 2,
+        "conditions": [],
+        "structured_inventory": {
+            "items": [
+                {
+                    "id": "item-longsword",
+                    "name": "Longsword",
+                    "item_type": "weapon",
+                    "weight": 3.0,
+                    "quantity": 1,
+                    "equipped": True,
+                },
+                {
+                    "id": "item-chain-mail",
+                    "name": "Chain Mail",
+                    "item_type": "armor",
+                    "weight": 55.0,
+                    "quantity": 1,
+                    "equipped": True,
+                },
+                {
+                    "id": "item-shield",
+                    "name": "Shield",
+                    "item_type": "shield",
+                    "weight": 6.0,
+                    "quantity": 1,
+                    "equipped": True,
+                },
+            ],
+            "equipment": {
+                "main_hand": "item-longsword",
+                "off_hand": "item-shield",
+                "armor": "item-chain-mail",
+            },
+            "gold": 15,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Step 1: Game context flows through the /input endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestBuildGameContext:
+    """Tests for build_game_context producing a rich context dict."""
+
+    def test_context_includes_combat_stats_from_character(
+        self, db_session, fighter_character_data
+    ):
+        """build_game_context returns combat-relevant values from character data."""
+        # Pre-load character dict (simulating Scribe fetch)
+        context = build_game_context(
+            character_id="char-fighter-1",
+            campaign_id="campaign-1",
+            character_data=fighter_character_data,
+        )
+
+        assert context["character_id"] == "char-fighter-1"
+        assert context["campaign_id"] == "campaign-1"
+        assert context["character_name"] == "Thorn Ironforge"
+        assert context["character_class"] == "fighter"
+        assert context["character_level"] == "3"
+
+        # Combat values
+        assert context["current_hp"] == 28
+        assert context["max_hp"] == 31
+        assert context["proficiency_bonus"] == 2
+
+        # Equipped weapon derived from structured_inventory
+        assert context["equipped_weapon_name"] == "Longsword"
+        assert context["equipped_weapon_damage"] == "1d8"  # SRD longsword
+        assert "versatile" in context["equipped_weapon_properties"]
+
+        # Attack bonus = ability mod + proficiency
+        # STR 16 -> mod +3, proficiency +2 -> total +5
+        assert context["attack_bonus"] == 5
+        assert context["damage_modifier"] == 3  # STR modifier
+
+    def test_context_computes_ac_from_equipment(self, fighter_character_data):
+        """AC is calculated from equipped armor and shield."""
+        context = build_game_context(
+            character_id="char-fighter-1",
+            campaign_id="campaign-1",
+            character_data=fighter_character_data,
+        )
+        # Chain mail = 16 AC (no DEX), + 2 shield = 18
+        assert context["armor_class"] == 18
+
+    def test_context_fallback_for_missing_character(self):
+        """When character data is sparse, context has safe defaults."""
+        minimal_char = {
+            "id": "char-unknown",
+            "name": "Mystery",
+            "class": "Wizard",
+            "level": 1,
+        }
+        context = build_game_context(
+            character_id="char-unknown",
+            campaign_id="campaign-1",
+            character_data=minimal_char,
+        )
+        # Should not crash; provides defaults
+        assert context["character_id"] == "char-unknown"
+        assert context["character_level"] == "1"
+        assert context["attack_bonus"] == 2  # 0 mod + 2 proficiency
+
+    def test_context_finesse_weapon_uses_higher_mod(self):
+        """A finesse weapon should use the higher of STR/DEX modifiers."""
+        char = {
+            "id": "char-rogue",
+            "name": "Shadow",
+            "character_class": "rogue",
+            "level": 5,
+            "abilities": {
+                "strength": 10,
+                "dexterity": 18,
+                "constitution": 12,
+                "intelligence": 14,
+                "wisdom": 10,
+                "charisma": 8,
+            },
+            "hit_points": {"current": 33, "maximum": 33},
+            "structured_inventory": {
+                "items": [
+                    {
+                        "id": "item-rapier",
+                        "name": "Rapier",
+                        "item_type": "weapon",
+                        "equipped": True,
+                    }
+                ],
+                "equipment": {"main_hand": "item-rapier"},
+            },
+        }
+        context = build_game_context(
+            character_id="char-rogue",
+            campaign_id="campaign-1",
+            character_data=char,
+        )
+        # Rapier is finesse; DEX 18 -> +4 mod, proficiency at L5 = +3
+        assert context["attack_bonus"] == 7
+        assert context["damage_modifier"] == 4
+
+
+# ---------------------------------------------------------------------------
+# Step 2: Campaign ID is set on conversation threads
+# ---------------------------------------------------------------------------
+
+
+class TestConversationThreadCampaignId:
+    """Tests that campaign_id is wired into ConversationThread records."""
+
+    def test_new_thread_gets_campaign_id(self, db_session):
+        """When a new thread is created it should have the campaign_id set."""
+        from app.agents.dungeon_master_agent import DungeonMasterAgent
+
+        # Patch get_session_context to use our in-memory DB
+        def _ctx():
+            from contextlib import contextmanager
+
+            @contextmanager
+            def _session():
+                try:
+                    yield db_session
+                    db_session.flush()
+                except Exception:
+                    db_session.rollback()
+                    raise
+
+            return _session()
+
+        with patch("app.agents.dungeon_master_agent.get_session_context", _ctx):
+            dm = DungeonMasterAgent.__new__(DungeonMasterAgent)
+            dm._threads = {}
+            dm._fallback_mode = True
+
+            dm._get_or_create_thread("session-123", campaign_id="campaign-abc")
+
+            # Verify the DB record
+            row = (
+                db_session.query(ConversationThread)
+                .filter(ConversationThread.session_id == "session-123")
+                .first()
+            )
+            assert row is not None
+            assert row.campaign_id == "campaign-abc"
+            assert row.agent_name == "DM"
+
+    def test_existing_thread_updated_with_campaign_id(self, db_session):
+        """If a thread exists without campaign_id, it gets back-filled."""
+        # Pre-create a thread without campaign_id
+        thread = ConversationThread(
+            id=str(uuid.uuid4()),
+            session_id="session-456",
+            agent_name="DM",
+            messages=[],
+            campaign_id=None,
+        )
+        db_session.add(thread)
+        db_session.commit()
+
+        from app.agents.dungeon_master_agent import DungeonMasterAgent
+
+        def _ctx():
+            from contextlib import contextmanager
+
+            @contextmanager
+            def _session():
+                try:
+                    yield db_session
+                    db_session.flush()
+                except Exception:
+                    db_session.rollback()
+                    raise
+
+            return _session()
+
+        with patch("app.agents.dungeon_master_agent.get_session_context", _ctx):
+            dm = DungeonMasterAgent.__new__(DungeonMasterAgent)
+            dm._threads = {}
+            dm._fallback_mode = True
+
+            dm._get_or_create_thread("session-456", campaign_id="campaign-xyz")
+
+            db_session.refresh(thread)
+            assert thread.campaign_id == "campaign-xyz"
+
+
+# ---------------------------------------------------------------------------
+# Step 4: Combat resolution uses character equipment
+# ---------------------------------------------------------------------------
+
+
+class TestCombatUsesEquipment:
+    """Tests that combat orchestration passes equipment stats."""
+
+    def test_orchestration_passes_weapon_stats(self):
+        """_call_combat_mc should include weapon and attack data from state."""
+        from app.agents.orchestration import _call_combat_mc
+
+        state = {
+            "character_id": "char-1",
+            "attack_bonus": 5,
+            "equipped_weapon_damage": "1d8",
+            "damage_modifier": 3,
+            "equipped_weapon_name": "Longsword",
+            "equipped_weapon_properties": ["versatile"],
+            "proficiency_bonus": 2,
+        }
+
+        # Mock the combat MC agent to capture what action_data it receives
+        mock_combat_mc = MagicMock()
+        captured = {}
+
+        async def _capture_action(encounter_id, action_data):
+            captured.update(action_data)
+            return {"success": True}
+
+        mock_combat_mc.process_combat_action = _capture_action
+
+        with patch(
+            "app.agents.combat_mc_agent.get_combat_mc",
+            return_value=mock_combat_mc,
+        ):
+            import asyncio
+
+            result = asyncio.run(
+                _call_combat_mc("I attack the goblin", state)
+            )
+
+        assert result is not None
+        key, value = result
+        assert key == "combat_update"
+
+        # Verify equipment stats were forwarded
+        assert captured["attack_bonus"] == 5
+        assert captured["damage_dice"] == "1d8"
+        assert captured["damage_modifier"] == 3
+        assert captured["weapon_name"] == "Longsword"
+
+    def test_fallback_combat_uses_damage_dice_key(self):
+        """Fallback combat should accept damage_dice and damage_modifier."""
+        from app.agents.combat_mc_agent import CombatMCAgent
+
+        agent = CombatMCAgent.__new__(CombatMCAgent)
+        agent._fallback_mode = True
+        agent.rules_engine = None
+        agent.active_combats = {}
+        agent.fallback_mechanics = {
+            "ability_modifiers": {},
+            "base_proficiency_bonus": 2,
+            "base_armor_class": 10,
+            "base_hit_points": 8,
+        }
+
+        encounter = {
+            "status": "active",
+            "enemies": [],
+            "round": 1,
+            "turn_order": [],
+        }
+
+        action = {
+            "type": "attack",
+            "actor_id": "char-1",
+            "target_id": "enemy_1",
+            "attack_bonus": 5,
+            "target_ac": 10,  # Easy hit
+            "damage_dice": "1d8",
+            "damage_modifier": 3,
+        }
+
+        # Seed random to get a reliable hit
+        import random
+
+        random.seed(42)
+        result = agent._process_fallback_combat_action(encounter, action)
+
+        # The result should use the damage_dice and modifier
+        assert result["action_type"] == "attack"
+        # Either hit or miss is fine, but no crash
+        assert "message" in result
+
+
+# ---------------------------------------------------------------------------
+# Step 5: State updates enrichment
+# ---------------------------------------------------------------------------
+
+
+class TestBuildStateUpdates:
+    """Tests for build_state_updates enriching the response with game state."""
+
+    def test_includes_character_state(self):
+        """State updates should contain character_state with HP and conditions."""
+        context = {
+            "current_hp": 28,
+            "max_hp": 31,
+            "armor_class": 18,
+            "conditions": ["poisoned"],
+            "character_level": "3",
+            "equipped_weapon_name": "Longsword",
+            "equipped_weapon_damage": "1d8",
+            "attack_bonus": 5,
+            "spell_slots": None,
+        }
+        dm_response = {
+            "state_updates": {"last_action": "attack goblin"},
+        }
+
+        result = build_state_updates(context, dm_response)
+
+        assert "character_state" in result
+        char_state = result["character_state"]
+        assert char_state["current_hp"] == 28
+        assert char_state["max_hp"] == 31
+        assert char_state["armor_class"] == 18
+        assert char_state["conditions"] == ["poisoned"]
+        assert char_state["level"] == 3
+
+    def test_includes_equipped_weapon(self):
+        """State updates should include the equipped weapon details."""
+        context = {
+            "current_hp": 20,
+            "max_hp": 20,
+            "armor_class": 14,
+            "conditions": [],
+            "character_level": "1",
+            "equipped_weapon_name": "Shortsword",
+            "equipped_weapon_damage": "1d6",
+            "attack_bonus": 5,
+            "spell_slots": None,
+        }
+        dm_response = {"state_updates": {}}
+
+        result = build_state_updates(context, dm_response)
+
+        assert "equipped_weapon" in result
+        assert result["equipped_weapon"]["name"] == "Shortsword"
+        assert result["equipped_weapon"]["damage_dice"] == "1d6"
+        assert result["equipped_weapon"]["attack_bonus"] == 5
+
+    def test_includes_spell_slots_when_present(self):
+        """State updates should include spell slots for spellcasters."""
+        context = {
+            "current_hp": 15,
+            "max_hp": 15,
+            "armor_class": 12,
+            "conditions": [],
+            "character_level": "3",
+            "equipped_weapon_name": "",
+            "spell_slots": [{"level": 1, "total": 4, "used": 1}],
+        }
+        dm_response = {"state_updates": {}}
+
+        result = build_state_updates(context, dm_response)
+
+        assert "spell_slots" in result
+        assert result["spell_slots"][0]["level"] == 1
+
+    def test_preserves_dm_state_updates(self):
+        """DM-provided state updates should be preserved in the output."""
+        context = {
+            "current_hp": 20,
+            "max_hp": 20,
+            "armor_class": 10,
+            "conditions": [],
+            "character_level": "1",
+            "equipped_weapon_name": "",
+            "spell_slots": None,
+        }
+        dm_response = {
+            "state_updates": {"xp_gained": 50, "last_action": "explored cave"},
+        }
+
+        result = build_state_updates(context, dm_response)
+
+        assert result["xp_gained"] == 50
+        assert result["last_action"] == "explored cave"
+        # Character state is still included
+        assert "character_state" in result
+
+
+# ---------------------------------------------------------------------------
+# Step 3: Rules engine integration with weapon stats
+# ---------------------------------------------------------------------------
+
+
+class TestRulesEngineWeaponIntegration:
+    """Tests that the rules engine weapon lookup works for combat."""
+
+    def test_get_weapon_stats_longsword(self):
+        """get_weapon_stats should return correct stats for a longsword."""
+        stats = get_weapon_stats("longsword")
+        assert stats["damage_dice"] == "1d8"
+        assert stats["damage_type"] == "slashing"
+        assert "versatile" in stats["properties"]
+
+    def test_get_weapon_stats_rapier(self):
+        """get_weapon_stats should return finesse property for rapier."""
+        stats = get_weapon_stats("rapier")
+        assert stats["damage_dice"] == "1d8"
+        assert "finesse" in stats["properties"]
+
+    def test_get_weapon_stats_unknown_falls_back(self):
+        """Unknown weapons should get a safe default."""
+        stats = get_weapon_stats("enchanted moonblade")
+        assert stats["damage_dice"] == "1d4"
+        assert stats["damage_type"] == "bludgeoning"
+
+    def test_get_weapon_stats_shortbow_is_ranged(self):
+        """Ranged weapons should have ammunition property."""
+        stats = get_weapon_stats("shortbow")
+        assert "ammunition" in stats["properties"]


### PR DESCRIPTION
## Summary
- **Step 1**: Enhance `/input` endpoint to pass rich game state (character HP, equipment, AC, attack bonuses, spell slots) via `build_game_context()` instead of a minimal context dict
- **Step 2**: Wire `campaign_id` onto `ConversationThread` records so conversation history is associated with campaigns and can be resumed on load
- **Step 3 & 4**: Forward character equipment stats (weapon damage dice, attack bonus, damage modifier, proficiency) through the orchestration layer to the combat MC agent; both fallback and plugin-based combat resolution now prefer `damage_dice` and `damage_modifier` from game context
- **Step 5**: Enrich `/input` responses with `build_state_updates()` containing `character_state` (HP, AC, conditions, level), equipped weapon details, and spell slots
- **Step 6**: Add 16 tests covering context building, thread campaign wiring, combat equipment forwarding, state update enrichment, and weapon lookup integration

## Changed files
| File | Change |
|------|--------|
| `backend/app/api/routes/session_routes.py` | Use `build_game_context()` and `build_state_updates()` in `/input` |
| `backend/app/agents/dungeon_master_agent.py` | Pass `campaign_id` when creating/loading conversation threads |
| `backend/app/agents/orchestration.py` | Forward equipment/combat stats to combat MC agent |
| `backend/app/agents/combat_mc_agent.py` | Prefer `damage_dice`/`damage_modifier` from game context in combat |
| `backend/app/services/game_context_service.py` | New: derive equipment-based values when pre-loaded character data is passed |
| `backend/tests/test_game_engine_wiring.py` | New: 16 tests for end-to-end game engine wiring |

## Test plan
- [x] All 16 new tests pass (`test_game_engine_wiring.py`)
- [x] Full test suite: 1080 passed, 6 skipped, 3 xfailed
- [ ] Manual verification: start a campaign, send player input, confirm response includes `character_state` in `state_updates`
- [ ] Manual verification: resume a campaign and confirm conversation thread has `campaign_id` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)