### PR TITLE
infra: complete Azure Developer CLI (azd) integration

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -7,6 +7,7 @@ metadata:
 infra:
   provider: bicep
   path: infra
+  module: main
 
 services:
   backend:
@@ -26,14 +27,26 @@ services:
     # Vite writes the production build to frontend/dist
     dist: dist
 
+pipeline:
+  provider: github
+
 hooks:
+  preprovision:
+    shell: sh
+    run: |
+      echo "Pre-provision: Validating environment configuration..."
+      if [ -z "${AZURE_LOCATION:-}" ]; then
+        echo "Hint: Set your preferred region with 'azd env set AZURE_LOCATION uksouth'"
+      fi
+    continueOnError: true
+
   # Generate the TypeScript API client from the running backend before packaging
   # the frontend.  Requires the backend to be reachable at localhost:8000.
   prepackage:
     shell: sh
     run: |
       echo "Pre-package: Generating TypeScript API client from backend OpenAPI schema..."
-      cd frontend && npm run generate:api || echo "Warning: API client generation skipped (backend must be running on localhost:8000)."
+      cd frontend && bun run generate:api || echo "Warning: API client generation skipped (backend must be running on localhost:8000)."
     continueOnError: true
 
   postprovision:
@@ -41,13 +54,13 @@ hooks:
     run: |
       echo "Post-provision: Infrastructure is ready."
       echo ""
+      echo "Bicep outputs have been saved to your azd environment."
+      echo "View them with: azd env get-values"
+      echo ""
       echo "Required environment variables – set these with 'azd env set <KEY> <VALUE>':"
-      echo "  AZURE_OPENAI_ENDPOINT          – Azure OpenAI resource endpoint"
-      echo "  AZURE_OPENAI_API_KEY           – Azure OpenAI API key"
-      echo "  AZURE_OPENAI_CHAT_DEPLOYMENT   – Primary chat model deployment (e.g. gpt-4o-mini)"
-      echo "  AZURE_OPENAI_MINI_DEPLOYMENT   – Cheaper model for structured tasks (e.g. gpt-4o-mini)"
+      echo "  AZURE_OPENAI_ENDPOINT            – Azure OpenAI resource endpoint"
+      echo "  AZURE_OPENAI_API_KEY             – Azure OpenAI API key (optional if using managed identity)"
+      echo "  AZURE_OPENAI_CHAT_DEPLOYMENT     – Primary chat model deployment (e.g. gpt-4o-mini)"
       echo "  AZURE_OPENAI_EMBEDDING_DEPLOYMENT – Embedding model deployment (e.g. text-embedding-ada-002)"
-      echo "  AZURE_OPENAI_DALLE_DEPLOYMENT  – Image-generation deployment (e.g. gpt-image-1-mini)"
-      echo "  AZURE_AI_PROJECT_ENDPOINT      – Azure AI Foundry project endpoint"
-      echo "  STORAGE_CONNECTION_STRING      – Azure Storage account connection string"
+      echo "  AZURE_OPENAI_DALLE_DEPLOYMENT    – Image-generation deployment (e.g. gpt-image-1-mini)"
     continueOnError: false

--- a/docs/azd-quickstart.md
+++ b/docs/azd-quickstart.md
@@ -1,0 +1,122 @@
+# Azure Developer CLI Quick Start
+
+This guide covers deploying Secure the Realm using [Azure Developer CLI (`azd`)](https://learn.microsoft.com/azure/developer/azure-developer-cli/overview?WT.mc_id=AI-MVP-5004204).
+
+## Prerequisites
+
+- [Azure Developer CLI](https://learn.microsoft.com/azure/developer/azure-developer-cli/install-azd?WT.mc_id=AI-MVP-5004204) v1.5+
+- An Azure subscription with permissions to create resources
+- Docker (for building the backend container image)
+
+## One-command deploy
+
+```bash
+azd up
+```
+
+This provisions all infrastructure (Container Apps, Static Web App, PostgreSQL, Key Vault, Storage, Application Insights) and deploys both the backend and frontend.
+
+On first run, `azd` will prompt you for:
+- **Environment name** -- used as a prefix for all Azure resources
+- **Azure location** -- the region to deploy to (e.g. `uksouth`)
+- **Azure subscription** -- which subscription to bill
+
+## Post-deploy configuration
+
+After `azd up` completes, set the Azure OpenAI configuration:
+
+```bash
+azd env set AZURE_OPENAI_ENDPOINT https://your-openai-resource.openai.azure.com/
+azd env set AZURE_OPENAI_CHAT_DEPLOYMENT gpt-4o-mini
+azd env set AZURE_OPENAI_EMBEDDING_DEPLOYMENT text-embedding-ada-002
+azd env set AZURE_OPENAI_DALLE_DEPLOYMENT gpt-image-1-mini
+```
+
+Then redeploy to pick up the new values:
+
+```bash
+azd deploy
+```
+
+## Environment management
+
+```bash
+# Create a dev environment
+azd env new dev
+azd env set AZURE_LOCATION uksouth
+
+# Create a prod environment
+azd env new prod
+azd env set AZURE_LOCATION uksouth
+
+# Switch between environments
+azd env select dev
+
+# View current environment values
+azd env get-values
+
+# List all environments
+azd env list
+```
+
+## Common commands
+
+| Command | Description |
+|---|---|
+| `azd up` | Provision infrastructure and deploy code |
+| `azd provision` | Provision infrastructure only (no code deploy) |
+| `azd deploy` | Deploy code only (infrastructure must exist) |
+| `azd down` | Tear down all provisioned resources |
+| `azd monitor --overview` | Open the Application Insights dashboard |
+| `azd monitor --live` | Open live metrics stream |
+| `azd env get-values` | Show all environment variable values |
+
+## Pipeline setup (GitHub Actions with OIDC)
+
+```bash
+azd pipeline config
+```
+
+This configures federated credentials for GitHub Actions using OpenID Connect -- no service principal secrets needed. It creates:
+- An Azure AD app registration
+- Federated identity credentials for your GitHub repository
+- GitHub repository secrets (`AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`)
+
+See the [azd pipeline documentation](https://learn.microsoft.com/azure/developer/azure-developer-cli/configure-devops-pipeline?WT.mc_id=AI-MVP-5004204) for details.
+
+## Architecture
+
+`azd` uses the following project structure:
+
+```
+azure.yaml              # Service definitions and hooks
+infra/
+  main.bicep            # Infrastructure-as-code (subscription-scoped)
+  main.bicepparam       # Default parameter values
+  modules/              # Reusable Bicep modules
+  parameters/
+    dev.bicepparam      # Development environment defaults
+    prod.bicepparam     # Production environment defaults
+```
+
+The infrastructure provisions:
+- **Container Apps** environment with the backend API
+- **Static Web App** for the frontend
+- **PostgreSQL Flexible Server** for persistent storage
+- **Azure Key Vault** for secrets
+- **Azure Storage** for blob/file storage
+- **Container Registry** for Docker images
+- **Application Insights** + Log Analytics for observability
+- **Managed Identity** for passwordless Azure service authentication
+- **Cost budget** with alert notifications
+
+## Troubleshooting
+
+**`azd up` fails during provisioning**
+Check that your subscription has quota for the resources in the target region. Run `azd provision` separately with `--debug` for detailed logs.
+
+**Frontend shows API errors after deploy**
+The frontend build embeds the backend URL at build time. Run `azd deploy` again after the backend is healthy.
+
+**Switching environments**
+The `.azure/` directory stores local environment config (including secrets) and is gitignored. Each developer manages their own environments locally.


### PR DESCRIPTION
## Summary
- **azure.yaml**: Added `module: main` to infra section, `pipeline.provider: github`, and a `preprovision` hook. Fixed `prepackage` hook to use `bun` instead of `npm`. Streamlined `postprovision` output by removing stale environment variable references (AZURE_OPENAI_MINI_DEPLOYMENT, AZURE_AI_PROJECT_ENDPOINT, STORAGE_CONNECTION_STRING) and noting that managed identity makes the API key optional.
- **docs/azd-quickstart.md**: New quickstart guide covering one-command deploy (`azd up`), environment management, common commands, OIDC pipeline setup, and troubleshooting.

Closes #513

## Test plan
- [ ] Verify `azd init` recognises the project structure correctly
- [ ] Verify `azd provision` runs the preprovision hook and deploys infrastructure
- [ ] Verify `azd deploy` builds and deploys both backend (Container App) and frontend (Static Web App)
- [ ] Verify `azd pipeline config` sets up GitHub Actions OIDC credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)