### PR TITLE
fix: Phase 3 - combat system overhaul (initiative, turns, encounters, spells, persistence, narration)

### DIFF
--- a/backend/app/agents/combat_mc_agent.py
+++ b/backend/app/agents/combat_mc_agent.py
@@ -106,6 +106,12 @@ class CombatMCAgent(BaseAgent):
 
         if not self._fallback_mode:
             self._register_skills()
+            try:
+                from app.azure_openai_client import azure_openai_client
+
+                self.azure_client = azure_openai_client
+            except Exception:
+                logger.debug("Azure OpenAI client unavailable for Combat MC narration")
         else:
             self._initialize_fallback_mechanics()
 
@@ -188,6 +194,42 @@ class CombatMCAgent(BaseAgent):
                 "notation": dice_notation,
                 "fallback": True,
             }
+
+    async def _narrate_result(self, rule_text: str) -> str:
+        """Enhance a bare rule string with LLM narration when available.
+
+        Falls back to the original *rule_text* when the AI client is
+        not configured or the call fails.
+        """
+        if self._fallback_mode or not getattr(self, "azure_client", None):
+            return rule_text
+
+        try:
+            prompt = (
+                "You are a dramatic D&D 5e combat narrator. Given the "
+                "following mechanical combat result, write 1-2 vivid "
+                "sentences describing what happens. Keep the original "
+                "numbers but wrap them in exciting prose.\n\n"
+                f"Result: {rule_text}"
+            )
+            narration = await self.azure_client.chat_completion(
+                messages=[
+                    {
+                        "role": "system",
+                        "content": (
+                            "Narrate D&D combat moments dramatically "
+                            "in 1-2 sentences."
+                        ),
+                    },
+                    {"role": "user", "content": prompt},
+                ],
+                temperature=0.8,
+                max_tokens=120,
+            )
+            return narration.strip() if narration else rule_text
+        except Exception as exc:
+            logger.debug("Combat narration LLM call failed: %s", exc)
+            return rule_text
 
     async def create_encounter(
         self, party_info: dict[str, Any], narrative_context: dict[str, Any]
@@ -386,10 +428,15 @@ class CombatMCAgent(BaseAgent):
                 return {"error": "Combat is not currently active"}
 
             if self._fallback_mode:
-                # Use fallback combat processing
-                return self._process_fallback_combat_action(encounter, action_data)
-            # Use plugin-based combat processing
-            return self._process_plugin_combat_action(encounter, action_data)
+                result = self._process_fallback_combat_action(encounter, action_data)
+            else:
+                result = self._process_plugin_combat_action(encounter, action_data)
+
+            # Enrich the bare rule message with AI narration (#697)
+            if "message" in result and "error" not in result:
+                result["narration"] = await self._narrate_result(result["message"])
+
+            return result
 
         except Exception as e:
             logger.error("Error processing combat action: %s", str(e))

--- a/backend/app/agents/combat_mc_agent.py
+++ b/backend/app/agents/combat_mc_agent.py
@@ -311,24 +311,17 @@ class CombatMCAgent(BaseAgent):
 
             encounter = self.active_combats[encounter_id]
 
-            # Roll initiative for all participants
+            # Roll initiative for all participants using DiceRoller
+            # for consistent d20 + DEX modifier rolls (#704).
             participants = []
 
             # Players
             for player in party_members:
-                if self._fallback_mode:
-                    # Use fallback d20 roll
-                    dex_mod = (
-                        player.get("abilities", {}).get("dexterity", 10) - 10
-                    ) // 2
-                    roll_result = self._fallback_roll_d20(dex_mod)
-                    initiative = roll_result["total"]
-                else:
-                    # Use plugin-based rolling when available
-                    dex_mod = (
-                        player.get("abilities", {}).get("dexterity", 10) - 10
-                    ) // 2
-                    initiative = random.randint(1, 20) + dex_mod  # noqa: S311
+                dex_mod = (
+                    player.get("abilities", {}).get("dexterity", 10) - 10
+                ) // 2
+                roll_result = DiceRoller.roll_d20(modifier=dex_mod)
+                initiative = roll_result["total"]
 
                 participants.append(
                     {
@@ -341,14 +334,9 @@ class CombatMCAgent(BaseAgent):
 
             # Enemies
             for enemy in encounter["enemies"]:
-                if self._fallback_mode:
-                    # Use fallback d20 roll with simple modifier
-                    initiative_mod = random.randint(-2, 2)  # noqa: S311
-                    roll_result = self._fallback_roll_d20(initiative_mod)
-                    initiative = roll_result["total"]
-                else:
-                    # Use simple random roll
-                    initiative = random.randint(1, 20) + random.randint(-2, 2)  # noqa: S311
+                dex_mod = enemy.get("dex_modifier", 0)
+                roll_result = DiceRoller.roll_d20(modifier=dex_mod)
+                initiative = roll_result["total"]
 
                 enemy["initiative"] = initiative
                 participants.append(

--- a/backend/app/agents/orchestration.py
+++ b/backend/app/agents/orchestration.py
@@ -29,6 +29,24 @@ COMBAT_KEYWORDS: list[str] = [
     "sword",
     "cast spell at",
     "shoot",
+    # Spell-casting phrases — "I cast Fireball", "cast healing word", etc.
+    "i cast ",
+    "cast ",
+    "casting ",
+    "use spell",
+    "fireball",
+    "magic missile",
+    "eldritch blast",
+    "smite",
+    "healing word",
+    "cure wounds",
+]
+
+# Regex patterns that also trigger combat routing (checked separately from
+# the simple substring keywords above).  These catch natural-language spell
+# invocations such as "I cast Fireball at the dragon".
+_COMBAT_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"\bcast(?:s|ing)?\s+\w+", re.IGNORECASE),
 ]
 
 EXPLORATION_KEYWORDS: list[str] = [
@@ -78,8 +96,10 @@ def detect_agent_triggers(dm_response: str, player_input: str) -> list[str]:
     triggers: list[str] = []
     combined = f"{player_input} {dm_response}".lower()
 
-    # Combat triggers
-    if any(kw in combined for kw in COMBAT_KEYWORDS):
+    # Combat triggers — simple keyword substring check plus regex patterns
+    has_combat_keyword = any(kw in combined for kw in COMBAT_KEYWORDS)
+    has_combat_pattern = any(p.search(combined) for p in _COMBAT_PATTERNS)
+    if has_combat_keyword or has_combat_pattern:
         triggers.append("combat_mc")
 
     # Exploration / narrative triggers

--- a/backend/app/api/routes/combat_routes.py
+++ b/backend/app/api/routes/combat_routes.py
@@ -8,6 +8,7 @@ from typing import Any
 from fastapi import APIRouter, HTTPException, status
 
 from app.agents.scribe_agent import get_scribe
+from app.utils.dice import DiceRoller
 
 logger = logging.getLogger(__name__)
 
@@ -96,7 +97,7 @@ async def process_combat_turn(combat_id: str, turn_data: dict[str, Any]) -> dict
         dice_result = turn_data.get("dice_result")
 
         # Process the combat action
-        turn_result = {
+        turn_result: dict[str, Any] = {
             "combat_id": combat_id,
             "character_id": character_id,
             "action": action_type,
@@ -107,22 +108,24 @@ async def process_combat_turn(combat_id: str, turn_data: dict[str, Any]) -> dict
             "next_turn": True,
         }
 
-        if action_type == "attack" and dice_result:
-            # Process attack
-            target_ac = turn_data.get("target_ac", 15)  # Default AC
-            if dice_result["total"] >= target_ac:
-                # Hit! Calculate damage
-                damage_dice = turn_data.get("damage_dice", "1d6")
-                from app.plugins.rules_engine_plugin import RulesEnginePlugin
+        if action_type == "attack":
+            # Roll attack if the caller did not supply a pre-rolled result
+            attack_bonus = turn_data.get("attack_bonus", 0)
+            if dice_result is None:
+                dice_result = DiceRoller.roll_d20(modifier=attack_bonus)
 
-                rules_engine = RulesEnginePlugin()
-                damage_result = rules_engine.roll_dice(damage_dice)
+            target_ac = turn_data.get("target_ac", 15)
+            if dice_result["total"] >= target_ac:
+                # Hit -- roll damage
+                damage_dice = turn_data.get("damage_dice", "1d6")
+                damage_result = DiceRoller.roll_damage(damage_dice)
 
                 turn_result.update(
                     {
                         "success": True,
                         "damage": damage_result["total"],
                         "description": f"Attack hits for {damage_result['total']} damage!",
+                        "attack_roll": dice_result,
                         "damage_roll": damage_result,
                     }
                 )
@@ -130,7 +133,11 @@ async def process_combat_turn(combat_id: str, turn_data: dict[str, Any]) -> dict
                 turn_result.update(
                     {
                         "success": False,
-                        "description": f"Attack misses (rolled {dice_result['total']} vs AC {target_ac})",
+                        "description": (
+                            f"Attack misses (rolled {dice_result['total']} "
+                            f"vs AC {target_ac})"
+                        ),
+                        "attack_roll": dice_result,
                     }
                 )
 

--- a/backend/app/api/routes/combat_routes.py
+++ b/backend/app/api/routes/combat_routes.py
@@ -8,11 +8,66 @@ from typing import Any
 from fastapi import APIRouter, HTTPException, status
 
 from app.agents.scribe_agent import get_scribe
+from app.database import get_session_context
+from app.models.db_models import CombatState
 from app.utils.dice import DiceRoller
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["combat"])
+
+
+def _persist_combat(combat_id: str, data: dict[str, Any]) -> None:
+    """Save or update a combat encounter in the database."""
+    try:
+        with get_session_context() as db:
+            row = db.query(CombatState).filter(CombatState.id == combat_id).first()
+            if row:
+                row.status = data.get("status", row.status)
+                row.round = data.get("round", row.round)
+                row.current_turn = data.get("current_turn", row.current_turn)
+                row.initiative_order = data.get("initiative_order", row.initiative_order)
+                row.combat_log = data.get("combat_log", row.combat_log)
+                row.updated_at = datetime.now(UTC)
+            else:
+                row = CombatState(
+                    id=combat_id,
+                    session_id=data.get("session_id", ""),
+                    status=data.get("status", "active"),
+                    round=data.get("round", 1),
+                    current_turn=data.get("current_turn", 0),
+                    initiative_order=data.get("initiative_order", []),
+                    participants=data.get("participants", []),
+                    environment=data.get("environment", "standard"),
+                    combat_log=data.get("combat_log", []),
+                )
+                db.add(row)
+            db.commit()
+    except Exception as exc:
+        logger.warning("Failed to persist combat state %s: %s", combat_id, exc)
+
+
+def _load_combat(combat_id: str) -> dict[str, Any] | None:
+    """Load a combat encounter from the database, or None if not found."""
+    try:
+        with get_session_context() as db:
+            row = db.query(CombatState).filter(CombatState.id == combat_id).first()
+            if row is None:
+                return None
+            return {
+                "combat_id": row.id,
+                "session_id": row.session_id,
+                "status": row.status,
+                "round": row.round,
+                "current_turn": row.current_turn,
+                "initiative_order": row.initiative_order,
+                "participants": row.participants,
+                "environment": row.environment,
+                "combat_log": row.combat_log,
+            }
+    except Exception as exc:
+        logger.warning("Failed to load combat state %s: %s", combat_id, exc)
+        return None
 
 
 @router.post("/combat/initialize", response_model=dict[str, Any])
@@ -71,8 +126,9 @@ async def initialize_combat(combat_data: dict[str, Any]) -> dict[str, Any]:
         # Sort by initiative (highest first)
         initiative_order.sort(key=lambda x: x["initiative"], reverse=True)
 
-        return {
-            "combat_id": f"combat_{session_id}_{uuid.uuid4().hex[:8]}",
+        combat_id = f"combat_{session_id}_{uuid.uuid4().hex[:8]}"
+        result = {
+            "combat_id": combat_id,
             "session_id": session_id,
             "status": "active",
             "round": 1,
@@ -82,6 +138,20 @@ async def initialize_combat(combat_data: dict[str, Any]) -> dict[str, Any]:
             "battle_map_requested": True,
             "started_at": str(datetime.now(UTC)),
         }
+
+        # Persist to database so combat survives restarts (#701)
+        _persist_combat(combat_id, {
+            "session_id": session_id,
+            "status": "active",
+            "round": 1,
+            "current_turn": 0,
+            "initiative_order": initiative_order,
+            "participants": participants,
+            "environment": environment,
+            "combat_log": [],
+        })
+
+        return result
 
     except Exception as e:
         raise HTTPException(
@@ -147,6 +217,13 @@ async def process_combat_turn(combat_id: str, turn_data: dict[str, Any]) -> dict
                 )
 
         turn_result["timestamp"] = str(datetime.now(UTC))
+
+        # Append to the persistent combat log (#701)
+        existing = _load_combat(combat_id)
+        if existing is not None:
+            log = list(existing.get("combat_log", []))
+            log.append(turn_result)
+            _persist_combat(combat_id, {"combat_log": log})
         return turn_result
 
     except Exception as e:

--- a/backend/app/api/routes/combat_routes.py
+++ b/backend/app/api/routes/combat_routes.py
@@ -23,43 +23,48 @@ async def initialize_combat(combat_data: dict[str, Any]) -> dict[str, Any]:
         participants = combat_data.get("participants", [])
         environment = combat_data.get("environment", "standard")
 
-        # Generate initiative order
-        initiative_order = []
+        # Generate initiative order — d20 + DEX modifier for every
+        # combatant, using DiceRoller for consistent randomness.
+        initiative_order: list[dict[str, Any]] = []
         for participant in participants:
+            dex_modifier = participant.get("dex_modifier", 0)
+
             if participant.get("type") == "player":
-                # Players roll initiative
-                from app.plugins.rules_engine_plugin import RulesEnginePlugin
+                # Try to pull DEX from the character sheet
+                try:
+                    character = await get_scribe().get_character(
+                        participant["character_id"]
+                    )
+                    if isinstance(character, dict) and "error" not in character:
+                        dex_score = (
+                            character.get("abilities", {}).get("dexterity", 10)
+                        )
+                        dex_modifier = (dex_score - 10) // 2
+                except Exception:
+                    logger.debug(
+                        "Could not fetch character %s for initiative; "
+                        "using dex_modifier from request.",
+                        participant.get("character_id"),
+                    )
 
-                rules_engine = RulesEnginePlugin()
-                character = await get_scribe().get_character(
-                    participant["character_id"]
-                )
-                if "error" not in character:
-                    dex_modifier = (character["abilities"]["dexterity"] - 10) // 2
-                    initiative_roll = rules_engine.roll_dice("1d20")
-                    initiative_total = initiative_roll["total"] + dex_modifier
-                else:
-                    initiative_total = 10  # Default if character not found
-
+                roll = DiceRoller.roll_d20(modifier=dex_modifier)
                 initiative_order.append(
                     {
                         "type": "player",
-                        "id": participant["character_id"],
+                        "id": participant.get("character_id", participant.get("id")),
                         "name": participant.get("name", "Player"),
-                        "initiative": initiative_total,
+                        "initiative": roll["total"],
                     }
                 )
             else:
-                # NPCs/enemies get random initiative
-                from random import randint
-
+                # NPCs / enemies
+                roll = DiceRoller.roll_d20(modifier=dex_modifier)
                 initiative_order.append(
                     {
                         "type": "npc",
-                        "id": participant["id"],
+                        "id": participant.get("id", "npc"),
                         "name": participant.get("name", "NPC"),
-                        "initiative": randint(1, 20)  # noqa: S311
-                        + participant.get("dex_modifier", 0),
+                        "initiative": roll["total"],
                     }
                 )
 

--- a/backend/app/encounter_balancer.py
+++ b/backend/app/encounter_balancer.py
@@ -342,11 +342,15 @@ def generate_balanced_encounter(
     selected: list[dict[str, Any]] = []
     remaining_budget = xp_budget
 
-    # Shuffle to add variety
+    avg_level = sum(party_levels) / len(party_levels)
+
+    # Sort by CR closeness to party level so better-matched monsters are
+    # selected first, then shuffle within equal-distance groups for variety.
     pool = list(location_pool)
     random.shuffle(pool)  # noqa: S311  # game randomness — no crypto requirement
-
-    avg_level = sum(party_levels) / len(party_levels)
+    pool.sort(
+        key=lambda m: abs((_cr_as_float(str(m.get("cr", "0"))) or 0) - avg_level)
+    )
 
     for monster in pool:
         monster_xp = monster.get("xp") or cr_to_xp(str(monster.get("cr", "0")))
@@ -447,14 +451,30 @@ def _filter_monsters_for_location(
     return filtered if filtered else monsters
 
 
-def _is_cr_appropriate(cr: str, avg_party_level: float) -> bool:
-    """Return True when the CR is within a reasonable range of the party level."""
-    cr_float = _CR_AS_FLOAT.get(str(cr))
-    if cr_float is None:
-        try:
-            cr_float = float(cr)
-        except (ValueError, TypeError):
-            return True  # Unknown CR — don't exclude
+def _cr_as_float(cr: str) -> float | None:
+    """Convert a CR string to a float, or None if unrecognised."""
+    val = _CR_AS_FLOAT.get(str(cr))
+    if val is not None:
+        return val
+    try:
+        return float(cr)
+    except (ValueError, TypeError):
+        return None
 
-    # Allow CR 0 through (party_level + 3) to give a reasonable range
-    return cr_float <= avg_party_level + 3
+
+def _is_cr_appropriate(cr: str, avg_party_level: float) -> bool:
+    """Return True when the CR is within a reasonable range of the party level.
+
+    Enforces both a lower and upper bound so that high-level parties
+    do not face trivially weak monsters and low-level parties are not
+    overwhelmed by overpowered foes.
+    """
+    cr_float = _cr_as_float(cr)
+    if cr_float is None:
+        return True  # Unknown CR — don't exclude
+
+    upper = avg_party_level + 3
+    # Lower bound: at least 1/4 of the average party level (minimum 0)
+    lower = max(0.0, avg_party_level / 4)
+
+    return lower <= cr_float <= upper

--- a/backend/app/models/db_models.py
+++ b/backend/app/models/db_models.py
@@ -203,6 +203,24 @@ class SessionParticipant(Base):
     joined_at = Column(DateTime, nullable=False, default=_utcnow)
 
 
+class CombatState(Base):
+    """Persistent combat encounter state, surviving server restarts."""
+
+    __tablename__ = "combat_states"
+
+    id = Column(String, primary_key=True, index=True)  # combat_id
+    session_id = Column(String, nullable=False, index=True)
+    status = Column(String, nullable=False, default="active")  # active, ended
+    round = Column(Integer, nullable=False, default=1)
+    current_turn = Column(Integer, nullable=False, default=0)
+    initiative_order = Column(JSON, nullable=False, default=list)
+    participants = Column(JSON, nullable=False, default=list)
+    environment = Column(String, nullable=False, default="standard")
+    combat_log = Column(JSON, nullable=False, default=list)
+    created_at = Column(DateTime, nullable=False, default=_utcnow)
+    updated_at = Column(DateTime, nullable=False, default=_utcnow, onupdate=_utcnow)
+
+
 class ConversationThread(Base):
     """Persistent conversation thread for agent interactions."""
 

--- a/backend/migrations/versions/c3d4e5f6a7b8_add_combat_states_table.py
+++ b/backend/migrations/versions/c3d4e5f6a7b8_add_combat_states_table.py
@@ -1,0 +1,55 @@
+"""add combat_states table
+
+Revision ID: c3d4e5f6a7b8
+Revises: b2c3d4e5f6a7
+Create Date: 2026-03-28 10:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c3d4e5f6a7b8"
+down_revision: str | Sequence[str] | None = "b2c3d4e5f6a7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create combat_states table for persistent combat encounters."""
+    op.create_table(
+        "combat_states",
+        sa.Column("id", sa.String(), nullable=False),
+        sa.Column("session_id", sa.String(), nullable=False),
+        sa.Column("status", sa.String(), nullable=False, server_default="active"),
+        sa.Column("round", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column("current_turn", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("initiative_order", sa.JSON(), nullable=False, server_default="[]"),
+        sa.Column("participants", sa.JSON(), nullable=False, server_default="[]"),
+        sa.Column("environment", sa.String(), nullable=False, server_default="standard"),
+        sa.Column("combat_log", sa.JSON(), nullable=False, server_default="[]"),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_combat_states_id"), "combat_states", ["id"], unique=False
+    )
+    op.create_index(
+        op.f("ix_combat_states_session_id"),
+        "combat_states",
+        ["session_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Drop combat_states table."""
+    op.drop_index(
+        op.f("ix_combat_states_session_id"), table_name="combat_states"
+    )
+    op.drop_index(op.f("ix_combat_states_id"), table_name="combat_states")
+    op.drop_table("combat_states")


### PR DESCRIPTION
## Summary
- Combat turns now auto-roll attack dice and resolve damage (#635)
- Combat init rolls d20+DEX and populates initiative_order (#613)
- Expand spell keyword routing for natural phrases like "I cast Fireball" (#703)
- Persist combat state to database (#701)
- Fix encounter generator CR selection and party_size budget (#630)
- Replace random.randint with DiceRoller for initiative (#704)
- Add LLM narration to combat results (#697)

Closes #635, closes #613, closes #703, closes #701, closes #630, closes #704, closes #697

🤖 Generated with [Claude Code](https://claude.com/claude-code)