### PR TITLE
fix: Phase 4 - frontend polish (15 UI fixes across editor, chat, character sheet, campaigns)

### DIFF
--- a/frontend/src/components/CampaignEditor.module.css
+++ b/frontend/src/components/CampaignEditor.module.css
@@ -52,6 +52,13 @@
   font-family: "Inter", system-ui, sans-serif;
 }
 
+.savedIndicator {
+  color: #4ade80;
+  font-size: 0.9rem;
+  font-weight: 500;
+  font-family: "Inter", system-ui, sans-serif;
+}
+
 .formGroup {
   margin-bottom: 1.5rem;
 }

--- a/frontend/src/components/CampaignEditor.tsx
+++ b/frontend/src/components/CampaignEditor.tsx
@@ -54,6 +54,7 @@ const CampaignEditor: React.FC<CampaignEditorProps> = ({
   const [aiGenerating, setAIGenerating] = useState(false);
   const [autoSave, setAutoSave] = useState(false);
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
+  const [showSavedFlash, setShowSavedFlash] = useState(false);
 
   const isEditing = !!campaign;
 
@@ -314,13 +315,9 @@ const CampaignEditor: React.FC<CampaignEditorProps> = ({
           setHasUnsavedChanges(false);
 
           if (!silent) {
-            // Show success message briefly
-            const originalName = formData.name;
-            setFormData((prev) => ({ ...prev, name: "✓ Saved!" }));
-            setTimeout(
-              () => setFormData((prev) => ({ ...prev, name: originalName })),
-              1000
-            );
+            // Show success indicator briefly
+            setShowSavedFlash(true);
+            setTimeout(() => setShowSavedFlash(false), 1500);
           }
         } else {
           const campaignData: CampaignCreateRequest = {
@@ -370,7 +367,10 @@ const CampaignEditor: React.FC<CampaignEditorProps> = ({
               />
               Auto-save
             </label>
-            {hasUnsavedChanges && (
+            {showSavedFlash && (
+              <span className={styles.savedIndicator}>✓ Saved!</span>
+            )}
+            {hasUnsavedChanges && !showSavedFlash && (
               <span className={styles.unsavedIndicator}>● Unsaved changes</span>
             )}
           </div>

--- a/frontend/src/components/CampaignEditor.tsx
+++ b/frontend/src/components/CampaignEditor.tsx
@@ -1,5 +1,5 @@
 import type React from "react";
-import { useCallback, useEffect, useId, useState } from "react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
 import {
   type AIAssistanceRequest,
   type AIContentGenerationRequest,
@@ -30,6 +30,8 @@ const CampaignEditor: React.FC<CampaignEditorProps> = ({
   const worldDescriptionId = useId();
   const toneId = useId();
   const homebrewRulesId = useId();
+
+  const textareaRefs = useRef<Record<string, HTMLTextAreaElement | null>>({});
 
   const [formData, setFormData] = useState({
     name: campaign?.name || "",
@@ -80,7 +82,7 @@ const CampaignEditor: React.FC<CampaignEditorProps> = ({
     field: string,
     format: "bold" | "italic" | "header" | "list"
   ) => {
-    const textarea = document.getElementById(field) as HTMLTextAreaElement;
+    const textarea = textareaRefs.current[field];
     if (!textarea) return;
 
     const start = textarea.selectionStart;
@@ -443,6 +445,9 @@ const CampaignEditor: React.FC<CampaignEditorProps> = ({
           </div>
           <textarea
             id={descriptionId}
+            ref={(el) => {
+              textareaRefs.current.description = el;
+            }}
             value={formData.description}
             onChange={(e) => handleInputChange("description", e.target.value)}
             placeholder="Brief description of your campaign..."
@@ -493,6 +498,9 @@ const CampaignEditor: React.FC<CampaignEditorProps> = ({
           </div>
           <textarea
             id={settingId}
+            ref={(el) => {
+              textareaRefs.current.setting = el;
+            }}
             value={formData.setting}
             onChange={(e) => handleInputChange("setting", e.target.value)}
             placeholder="Describe the world and setting for your campaign..."
@@ -549,6 +557,9 @@ const CampaignEditor: React.FC<CampaignEditorProps> = ({
           </div>
           <textarea
             id={worldDescriptionId}
+            ref={(el) => {
+              textareaRefs.current.world_description = el;
+            }}
             value={formData.world_description}
             onChange={(e) =>
               handleInputChange("world_description", e.target.value)

--- a/frontend/src/components/CampaignEditor.tsx
+++ b/frontend/src/components/CampaignEditor.tsx
@@ -239,19 +239,11 @@ const CampaignEditor: React.FC<CampaignEditorProps> = ({
         handleInputChange(activeField, enhancedValue);
       } else {
         console.error("AI content generation failed:", response.error);
-        // Fallback to the old behavior if generation fails
-        const enhancedValue = currentValue
-          ? `${currentValue}\n\n${suggestion}`
-          : suggestion;
-        handleInputChange(activeField, enhancedValue);
+        setError("AI content generation failed. Please try again.");
       }
     } catch (error) {
       console.error("Error generating AI content:", error);
-      // Fallback to the old behavior if request fails
-      const enhancedValue = currentValue
-        ? `${currentValue}\n\n${suggestion}`
-        : suggestion;
-      handleInputChange(activeField, enhancedValue);
+      setError("AI content generation failed. Please try again.");
     } finally {
       setAIGenerating(false);
       setShowAIAssistant(false);

--- a/frontend/src/components/CampaignGallery.tsx
+++ b/frontend/src/components/CampaignGallery.tsx
@@ -212,7 +212,10 @@ const CampaignGallery: React.FC<CampaignGalleryProps> = ({
                 className={`${styles.toneBadge} ${template.tone ? styles[template.tone] : ""}`}
                 variant="secondary"
               >
-                {template.tone}
+                {template.tone
+                  ? template.tone.charAt(0).toUpperCase() +
+                    template.tone.slice(1)
+                  : ""}
               </Badge>
             </CardHeader>
 

--- a/frontend/src/components/CampaignGallery.tsx
+++ b/frontend/src/components/CampaignGallery.tsx
@@ -93,7 +93,7 @@ const CampaignGallery: React.FC<CampaignGalleryProps> = ({
       setCloning(template.id);
       const clonedCampaign = await cloneCampaign({
         template_id: template.id,
-        new_name: `${template.name} (My Campaign)`,
+        name: `${template.name} (My Campaign)`,
       });
       onCampaignSelected(clonedCampaign);
     } catch (err) {

--- a/frontend/src/components/CampaignSelection.module.css
+++ b/frontend/src/components/CampaignSelection.module.css
@@ -288,6 +288,10 @@
   line-height: 1.6;
   font-family: "Inter", system-ui, sans-serif;
   font-size: 0.95rem;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
 .campaignMeta {

--- a/frontend/src/components/CampaignSelection.tsx
+++ b/frontend/src/components/CampaignSelection.tsx
@@ -1,6 +1,6 @@
 import type React from "react";
 import { useCallback, useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -18,6 +18,9 @@ const CampaignSelection: React.FC<CampaignSelectionProps> = ({
   onCampaignCreated,
 }) => {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const defaultTab =
+    searchParams.get("tab") === "my-campaigns" ? "my-campaigns" : "gallery";
   const [campaigns, setCampaigns] = useState<Campaign[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -88,7 +91,7 @@ const CampaignSelection: React.FC<CampaignSelectionProps> = ({
           </div>
         )}
 
-        <Tabs defaultValue="gallery" className={styles.campaignTabs}>
+        <Tabs defaultValue={defaultTab} className={styles.campaignTabs}>
           <div className={styles.managerHeader}>
             <div className={styles.headerContent}>
               <h2 className={styles.sectionTitle}>Campaign Hub</h2>

--- a/frontend/src/components/CampaignSelection.tsx
+++ b/frontend/src/components/CampaignSelection.tsx
@@ -152,7 +152,8 @@ const CampaignSelection: React.FC<CampaignSelectionProps> = ({
                                 variant="outline"
                                 className={`tone-badge ${campaign.tone}`}
                               >
-                                {campaign.tone}
+                                {campaign.tone.charAt(0).toUpperCase() +
+                                  campaign.tone.slice(1)}
                               </Badge>
                             )}
                             {campaign.template_id && (

--- a/frontend/src/components/CharacterSheet.module.css
+++ b/frontend/src/components/CharacterSheet.module.css
@@ -23,7 +23,7 @@
   margin: 0;
   color: var(--color-accent-gold); /* Gold for character name */
   font-size: 1.5rem;
-  font-family: "Cinzel Decorative", serif;
+  font-family: "Cinzel", serif;
   font-weight: 700;
   text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.5);
 }

--- a/frontend/src/components/CharacterSheet.tsx
+++ b/frontend/src/components/CharacterSheet.tsx
@@ -280,60 +280,43 @@ const CharacterSheet: React.FC<CharacterSheetProps> = ({ character }) => {
       <div className={styles.inventory}>
         <h3>Inventory</h3>
 
-        {/* Equipment Slots */}
-        <div className={styles.equipmentSlots}>
-          <h4>Equipment</h4>
-          <div className={styles.equipmentGrid}>
-            <div className={styles.equipmentSlot}>
-              <div className={styles.slotLabel}>Main Hand:</div>
-              <span>
-                {(character as any).equipment?.mainHand?.name || "Empty"}
-              </span>
+        {/* Equipment Slots — only show occupied slots */}
+        {(() => {
+          const eq = (character as any).equipment;
+          const slots: Array<{ label: string; name: string }> = [];
+          if (eq?.mainHand?.name)
+            slots.push({ label: "Main Hand", name: eq.mainHand.name });
+          if (eq?.offHand?.name)
+            slots.push({ label: "Off Hand", name: eq.offHand.name });
+          if (eq?.armor?.name)
+            slots.push({ label: "Armor", name: eq.armor.name });
+          if (eq?.shield?.name)
+            slots.push({ label: "Shield", name: eq.shield.name });
+          if (eq?.ring1?.name)
+            slots.push({ label: "Ring 1", name: eq.ring1.name });
+          if (eq?.ring2?.name)
+            slots.push({ label: "Ring 2", name: eq.ring2.name });
+          if (eq?.amulet?.name)
+            slots.push({ label: "Amulet", name: eq.amulet.name });
+          if (eq?.cloak?.name)
+            slots.push({ label: "Cloak", name: eq.cloak.name });
+
+          if (slots.length === 0) return null;
+
+          return (
+            <div className={styles.equipmentSlots}>
+              <h4>Equipment</h4>
+              <div className={styles.equipmentGrid}>
+                {slots.map((slot) => (
+                  <div key={slot.label} className={styles.equipmentSlot}>
+                    <div className={styles.slotLabel}>{slot.label}:</div>
+                    <span>{slot.name}</span>
+                  </div>
+                ))}
+              </div>
             </div>
-            <div className={styles.equipmentSlot}>
-              <div className={styles.slotLabel}>Off Hand:</div>
-              <span>
-                {(character as any).equipment?.offHand?.name || "Empty"}
-              </span>
-            </div>
-            <div className={styles.equipmentSlot}>
-              <div className={styles.slotLabel}>Armor:</div>
-              <span>
-                {(character as any).equipment?.armor?.name || "Unarmored"}
-              </span>
-            </div>
-            <div className={styles.equipmentSlot}>
-              <div className={styles.slotLabel}>Shield:</div>
-              <span>
-                {(character as any).equipment?.shield?.name || "None"}
-              </span>
-            </div>
-            <div className={styles.equipmentSlot}>
-              <div className={styles.slotLabel}>Ring 1:</div>
-              <span>
-                {(character as any).equipment?.ring1?.name || "Empty"}
-              </span>
-            </div>
-            <div className={styles.equipmentSlot}>
-              <div className={styles.slotLabel}>Ring 2:</div>
-              <span>
-                {(character as any).equipment?.ring2?.name || "Empty"}
-              </span>
-            </div>
-            <div className={styles.equipmentSlot}>
-              <div className={styles.slotLabel}>Amulet:</div>
-              <span>
-                {(character as any).equipment?.amulet?.name || "Empty"}
-              </span>
-            </div>
-            <div className={styles.equipmentSlot}>
-              <div className={styles.slotLabel}>Cloak:</div>
-              <span>
-                {(character as any).equipment?.cloak?.name || "Empty"}
-              </span>
-            </div>
-          </div>
-        </div>
+          );
+        })()}
 
         {/* Inventory Items */}
         <div className={styles.inventoryItems}>

--- a/frontend/src/components/ChatBox.tsx
+++ b/frontend/src/components/ChatBox.tsx
@@ -84,7 +84,7 @@ const ChatBox: React.FC<ChatBoxProps> = ({
         <div role="log" aria-live="polite" aria-label="Chat messages">
           {messages.map((message, index) => (
             <div
-              key={`${message.text}-${index}`}
+              key={`msg-${index}`}
               className={`${styles.message} ${message.sender === "player" ? styles.playerMessage : styles.dmMessage}`}
             >
               <div className={styles.messageSender}>

--- a/frontend/src/components/GameInterface.tsx
+++ b/frontend/src/components/GameInterface.tsx
@@ -260,7 +260,10 @@ const GameInterface: React.FC<GameInterfaceProps> = ({
     connectionType: "chat",
     campaignId: campaign.id!,
     onMessage: handleChatWebSocketMessage,
-    onConnect: () => console.log("Connected to chat WebSocket"),
+    onConnect: () => {
+      console.log("Connected to chat WebSocket");
+      setUseWebSocketFallback(false);
+    },
     onDisconnect: () => {
       console.log("Disconnected from chat WebSocket");
       setUseWebSocketFallback(true);

--- a/frontend/src/components/GameInterface.tsx
+++ b/frontend/src/components/GameInterface.tsx
@@ -253,7 +253,7 @@ const GameInterface: React.FC<GameInterfaceProps> = ({
 
   const { socket, isConnected } = useWebSocketSDK({
     connectionType: "campaign",
-    campaignId: campaign.id!,
+    campaignId: campaign.id ?? "",
     onMessage: handleWebSocketMessage,
     onConnect: () => console.log("Connected to campaign WebSocket"),
     onDisconnect: () => console.log("Disconnected from campaign WebSocket"),
@@ -262,7 +262,7 @@ const GameInterface: React.FC<GameInterfaceProps> = ({
 
   const { socket: chatSocket, isConnected: chatConnected } = useWebSocketSDK({
     connectionType: "chat",
-    campaignId: campaign.id!,
+    campaignId: campaign.id ?? "",
     onMessage: handleChatWebSocketMessage,
     onConnect: () => {
       console.log("Connected to chat WebSocket");
@@ -645,8 +645,8 @@ const GameInterface: React.FC<GameInterfaceProps> = ({
       setLoading(true);
 
       const response = await sendPlayerInput({
-        character_id: character.id!,
-        campaign_id: campaign.id!,
+        character_id: character.id ?? "",
+        campaign_id: campaign.id ?? "",
         message: message.trim(),
       });
 

--- a/frontend/src/components/GameInterface.tsx
+++ b/frontend/src/components/GameInterface.tsx
@@ -242,6 +242,10 @@ const GameInterface: React.FC<GameInterfaceProps> = ({
         console.log("Character update received:", message);
         break;
 
+      case "dm_floor_request":
+        setDmWantsFloor(true);
+        break;
+
       default:
         console.log("Unknown WebSocket message:", message);
     }

--- a/frontend/src/hooks/useRealtimeVoice.ts
+++ b/frontend/src/hooks/useRealtimeVoice.ts
@@ -1,4 +1,5 @@
 import { useCallback, useRef, useState } from "react";
+import { getApiBaseUrl } from "../utils/urls";
 
 type ConnectionState = "disconnected" | "connecting" | "connected" | "error";
 
@@ -40,7 +41,7 @@ export function useRealtimeVoice(): UseRealtimeVoiceReturn {
 
     try {
       // 1. Get ephemeral token from backend
-      const tokenRes = await fetch("/api/realtime/token");
+      const tokenRes = await fetch(`${getApiBaseUrl()}/api/realtime/token`);
       if (!tokenRes.ok) throw new Error("Failed to get realtime token");
       const { token, endpoint, deployment } = await tokenRes.json();
 

--- a/frontend/src/pages/CampaignEditPage.tsx
+++ b/frontend/src/pages/CampaignEditPage.tsx
@@ -28,7 +28,7 @@ const CampaignEditPage: React.FC = () => {
   };
 
   const handleCancel = () => {
-    navigate("/");
+    navigate("/?tab=my-campaigns");
   };
 
   if (loading) return <LoadingState message="Loading campaign..." />;

--- a/frontend/src/pages/CampaignNewPage.tsx
+++ b/frontend/src/pages/CampaignNewPage.tsx
@@ -11,7 +11,7 @@ const CampaignNewPage: React.FC = () => {
   };
 
   const handleCancel = () => {
-    navigate("/");
+    navigate("/?tab=my-campaigns");
   };
 
   return (


### PR DESCRIPTION
## Summary
- Fix formatting toolbar with React refs (#659)
- Normalise tone badges to Title Case (#633)
- Fix campaign clone field name (#660)
- Add CSS line-clamp for descriptions (#632)
- Reset WebSocket fallback on reconnection (#661)
- Use configured API URL for voice token (#662)
- Standardise fonts to Cinzel (#625)
- Collapse empty equipment slots (#627)
- Fix cancel navigation to My Campaigns tab (#637)
- Wire dmWantsFloor WebSocket state (#663)
- Use stable React keys for chat messages (#685)
- Separate save indicator state from formData (#691)

Closes #659, closes #633, closes #660, closes #632, closes #661, closes #662, closes #625, closes #627, closes #637, closes #663, closes #685, closes #691

🤖 Generated with [Claude Code](https://claude.com/claude-code)