### PR TITLE
fix: final fixes - battle map dimensions, editor tone sync, type safety

### DIFF
--- a/backend/app/api/routes/map_routes.py
+++ b/backend/app/api/routes/map_routes.py
@@ -31,6 +31,8 @@ class EnvironmentSpec(BaseModel):
 
 class StructuredMapRequest(BaseModel):
     environment: EnvironmentSpec = Field(default_factory=EnvironmentSpec)
+    width: int | None = Field(default=None, ge=5, le=100, description="Override grid width in tiles")
+    height: int | None = Field(default=None, ge=5, le=100, description="Override grid height in tiles")
     combat_context: dict[str, Any] | None = None
     seed: int | None = None
 
@@ -61,7 +63,9 @@ async def generate_structured_battle_map(
     """
     try:
         env = body.environment
-        width, height = _SIZE_DIMENSIONS.get(env.size, _SIZE_DIMENSIONS["medium"])
+        default_w, default_h = _SIZE_DIMENSIONS.get(env.size, _SIZE_DIMENSIONS["medium"])
+        width = body.width if body.width is not None else default_w
+        height = body.height if body.height is not None else default_h
 
         context: dict[str, Any] = {
             "location": env.location,

--- a/frontend/src/components/CampaignEditor.tsx
+++ b/frontend/src/components/CampaignEditor.tsx
@@ -58,6 +58,20 @@ const CampaignEditor: React.FC<CampaignEditorProps> = ({
 
   const isEditing = !!campaign;
 
+  // Sync form data when campaign prop changes (e.g. async load)
+  useEffect(() => {
+    if (campaign) {
+      setFormData({
+        name: campaign.name || "",
+        description: campaign.description || "",
+        setting: campaign.setting || "",
+        tone: campaign.tone || "heroic",
+        homebrew_rules: campaign.homebrew_rules?.join("\n") || "",
+        world_description: campaign.world_description || "",
+      });
+    }
+  }, [campaign]);
+
   // Track changes
   useEffect(() => {
     if (isEditing) {

--- a/frontend/src/components/GameInterface.tsx
+++ b/frontend/src/components/GameInterface.tsx
@@ -58,8 +58,11 @@ const extractErrorMessage = (
       }
     }
     // Check for general error message
-    else if ("message" in error && typeof (error as any).message === "string") {
-      return (error as any).message;
+    else if ("message" in error) {
+      const msg = (error as { message?: unknown }).message;
+      if (typeof msg === "string") {
+        return msg;
+      }
     }
   }
   return fallbackMessage;


### PR DESCRIPTION
## Summary
- Battle map structured endpoint now respects requested width/height (#614)
- Campaign editor syncs tone from loaded campaign data (#616)
- Replace `as any` type assertions with proper narrowing in GameInterface (#626)

Closes #614, closes #616, closes #626

🤖 Generated with [Claude Code](https://claude.com/claude-code)